### PR TITLE
Add "mix statues with bosses" flag

### DIFF
--- a/args/bosses.py
+++ b/args/bosses.py
@@ -11,7 +11,7 @@ def parse(parser):
                         help = "Boss battles randomized")
     bosses.add_argument("-bmbd", "--mix-bosses-dragons", action = "store_true",
                         help = "Shuffle/randomize bosses and dragons together")
-    bosses.add_argument("-bmbs", "--mix-bosses-statues", action = "store_true",
+    bosses.add_argument("-bmbs", "--mix-bosses-statues", action = "store_true", default = True,
                         help = "Shuffle/randomize bosses and statues together")
     bosses.add_argument("-srp3", "--shuffle-random-phunbaba3", action = "store_true",
                         help = "Apply Shuffle/Random to Phunbaba 3 (otherwise he will only appear in Mobliz WOR)")

--- a/args/bosses.py
+++ b/args/bosses.py
@@ -11,6 +11,8 @@ def parse(parser):
                         help = "Boss battles randomized")
     bosses.add_argument("-bmbd", "--mix-bosses-dragons", action = "store_true",
                         help = "Shuffle/randomize bosses and dragons together")
+    bosses.add_argument("-bmbs", "--mix-bosses-statues", action = "store_true",
+                        help = "Shuffle/randomize bosses and statues together")
     bosses.add_argument("-srp3", "--shuffle-random-phunbaba3", action = "store_true",
                         help = "Apply Shuffle/Random to Phunbaba 3 (otherwise he will only appear in Mobliz WOR)")
     bosses.add_argument("-bnds", "--boss-normalize-distort-stats", action = "store_true",
@@ -33,6 +35,8 @@ def flags(args):
 
     if args.mix_bosses_dragons:
         flags += " -bmbd"
+    if args.mix_bosses_statues:
+        flags += " -bmbs"
     if args.shuffle_random_phunbaba3:
         flags += " -srp3"
     if args.boss_normalize_distort_stats:
@@ -54,6 +58,7 @@ def options(args):
     return [
         ("Boss Battles", boss_battles),
         ("Mix Bosses & Dragons", args.mix_bosses_dragons),
+        ("Mix Bosses & Statues", args.mix_bosses_statues),
         ("Shuffle/Random Phunbaba 3", args.shuffle_random_phunbaba3),
         ("Normalize & Distort Stats", args.boss_normalize_distort_stats),
         ("Boss Experience", args.boss_experience),

--- a/args/bosses.py
+++ b/args/bosses.py
@@ -11,7 +11,7 @@ def parse(parser):
                         help = "Boss battles randomized")
     bosses.add_argument("-bmbd", "--mix-bosses-dragons", action = "store_true",
                         help = "Shuffle/randomize bosses and dragons together")
-    bosses.add_argument("-bmbs", "--mix-bosses-statues", action = "store_true", default = True,
+    bosses.add_argument("-bmbs", "--mix-bosses-statues", action = "store_true",
                         help = "Shuffle/randomize bosses and statues together")
     bosses.add_argument("-srp3", "--shuffle-random-phunbaba3", action = "store_true",
                         help = "Apply Shuffle/Random to Phunbaba 3 (otherwise he will only appear in Mobliz WOR)")

--- a/data/enemy_packs.py
+++ b/data/enemy_packs.py
@@ -18,6 +18,7 @@ class EnemyPacks():
     PHUNBABA3 = 386
     DOOM_GAZE = 349
 
+    # statues removed from shuffle pool with -bmbs flag
     DOOM=354
     GODDESS=355
     POLTERGEIST=356

--- a/data/enemy_packs.py
+++ b/data/enemy_packs.py
@@ -18,6 +18,10 @@ class EnemyPacks():
     PHUNBABA3 = 386
     DOOM_GAZE = 349
 
+    DOOM=354
+    GODDESS=355
+    POLTERGEIST=356
+
     def __init__(self, rom, args, formations):
         self.rom = rom
         self.args = args
@@ -37,6 +41,10 @@ class EnemyPacks():
 
     def _replaceable_bosses(self):
         replaceable = list(bosses.normal_pack_name)
+        if not self.args.mix_bosses_statues:
+            for boss in [self.DOOM, self.GODDESS, self.POLTERGEIST]:
+                replaceable.remove(boss)
+                self.event_boss_replacements[boss] = boss
         if not self.args.shuffle_random_phunbaba3:
             replaceable.remove(self.PHUNBABA3)
             self.event_boss_replacements[self.PHUNBABA3] = self.PHUNBABA3


### PR DESCRIPTION
This functions similarly to how we are currently excluding Phunbaba 3, in that he is naturally in the boss pool, but is removed under his respective flag. Using the same logic we can keep the statue fights in place

