### PR TITLE
Adding Magitek to Random, fixing Magitek reflect bug, giving all characters all Magiteks, adding rec6

### DIFF
--- a/args/commands.py
+++ b/args/commands.py
@@ -71,7 +71,7 @@ def flags(args):
     if args.random_exclude_command5 != NONE_COMMAND:
         flags += f" -rec5 {args.random_exclude_command5}"
     if args.random_exclude_command6 != NONE_COMMAND:
-        flags += f" -rec6 {args.random_exclude_command5}"
+        flags += f" -rec6 {args.random_exclude_command6}"
 
     return flags
 

--- a/args/commands.py
+++ b/args/commands.py
@@ -12,6 +12,7 @@ def parse(parser):
     commands.add_argument("-rec3", "--random-exclude-command3", type = int, choices = RANDOM_EXCLUDE_COMMANDS, metavar = "VALUE", default = NONE_COMMAND, help = "Exclude selected command from random possibilities")
     commands.add_argument("-rec4", "--random-exclude-command4", type = int, choices = RANDOM_EXCLUDE_COMMANDS, metavar = "VALUE", default = NONE_COMMAND, help = "Exclude selected command from random possibilities")
     commands.add_argument("-rec5", "--random-exclude-command5", type = int, choices = RANDOM_EXCLUDE_COMMANDS, metavar = "VALUE", default = NONE_COMMAND, help = "Exclude selected command from random possibilities")
+    commands.add_argument("-rec6", "--random-exclude-command6", type = int, choices = RANDOM_EXCLUDE_COMMANDS, metavar = "VALUE", default = NONE_COMMAND, help = "Exclude selected command from random possibilities")
 
 def process(args):
     if not args.commands:
@@ -43,6 +44,8 @@ def process(args):
         args.random_exclude_commands.append(args.random_exclude_command4)
     if args.random_exclude_command5 != NONE_COMMAND:
         args.random_exclude_commands.append(args.random_exclude_command5)
+    if args.random_exclude_command6 != NONE_COMMAND:
+        args.random_exclude_commands.append(args.random_exclude_command6)
 
     random_exists = "Random" in args.command_strings or "Random Unique" in args.command_strings
     blitz_excluded = name_id["Blitz"] in args.random_exclude_commands
@@ -67,6 +70,8 @@ def flags(args):
         flags += f" -rec4 {args.random_exclude_command4}"
     if args.random_exclude_command5 != NONE_COMMAND:
         flags += f" -rec5 {args.random_exclude_command5}"
+    if args.random_exclude_command6 != NONE_COMMAND:
+        flags += f" -rec6 {args.random_exclude_command5}"
 
     return flags
 
@@ -89,6 +94,7 @@ def options(args):
     add_exclude_command(args.random_exclude_command3)
     add_exclude_command(args.random_exclude_command4)
     add_exclude_command(args.random_exclude_command5)
+    add_exclude_command(args.random_exclude_command6)
 
     return result
 

--- a/constants/commands.py
+++ b/constants/commands.py
@@ -41,7 +41,7 @@ RANDOM_UNIQUE_COMMAND = 98
 NONE_COMMAND = 97   # none command id is 3 digits in base 10 (255), use a custom 2 digit value for args
 
 COMMAND_OPTIONS = ["Morph", "Steal", "SwdTech", "Throw", "Tools", "Blitz", "Runic", "Lore", "Sketch", "Slot", "Dance", "Rage", "Leap"]
-EXCLUDE_COMMANDS = ["Item", "Magic", "Revert", "Leap", "Mimic", "Row", "Def", "Summon", "MagiTek", "Empty", "Empty?", "None"]
+EXCLUDE_COMMANDS = ["Item", "Magic", "Revert", "Leap", "Mimic", "Row", "Def", "Summon", "Empty", "Empty?", "None"]
 
 RANDOM_POSSIBLE_COMMANDS = [option for option in sorted(name_id.keys()) if option not in EXCLUDE_COMMANDS and option != "Fight"]
 RANDOM_EXCLUDE_COMMANDS = [NONE_COMMAND] + [name_id[option] for option in RANDOM_POSSIBLE_COMMANDS]

--- a/data/data.py
+++ b/data/data.py
@@ -10,6 +10,7 @@ import data.blitzes as blitzes
 import data.lores as lores
 import data.rages as rages
 import data.dances as dances
+import data.magiteks as magiteks
 import data.espers as espers
 import data.shops as shops
 import data.coliseum as coliseum
@@ -51,6 +52,9 @@ class Data:
         self.dances = dances.Dances(rom, args, self.characters)
         self.dances.mod()
 
+        self.magiteks = magiteks.Magiteks(rom, args)
+        self.magiteks.mod()
+
         self.espers = espers.Espers(rom, args, self.spells, self.characters)
         self.espers.mod(self.dialogs)
 
@@ -73,6 +77,7 @@ class Data:
         self.lores.write()
         self.rages.write()
         self.dances.write()
+        self.magiteks.write()
         self.espers.write()
         self.shops.write()
         self.coliseum.write()

--- a/data/magitek.py
+++ b/data/magitek.py
@@ -1,0 +1,21 @@
+from data.ability_data import AbilityData
+import data.text as text
+
+class Magitek(AbilityData):
+    def __init__(self, id, name_data, ability_data):
+        super().__init__(id, ability_data)
+
+        self.id = id
+        self.name = text.get_string(name_data, text.TEXT2).rstrip('\0')
+
+    def name_data(self):
+        from data.magiteks import Magiteks
+        data = text.get_bytes(self.name, text.TEXT2)
+        data.extend([0xff] * (Magiteks.NAME_SIZE - len(data)))
+        return data
+
+    def get_name(self):
+        return self.name.strip('\0')
+
+    def print(self):
+        print(f"{self.id} {self.get_name()}")

--- a/data/magiteks.py
+++ b/data/magiteks.py
@@ -1,0 +1,77 @@
+from data.magitek import Magitek
+from data.ability_data import AbilityData
+from data.structures import DataBits, DataArray
+
+from memory.space import Bank, Reserve, Allocate, Write
+
+class Magiteks:
+    MAGITEK_COUNT = 8
+    FIRE_BEAM, BOLT_BEAM, ICE_BEAM, BIO_BLAST, HEAL_FORCE, CONFUSER, X_FER, TEKMISSILE = range(MAGITEK_COUNT)
+    DISABLED_MAGITEK = 0xFF
+
+    NAMES_START = 0x26f9ad 
+    NAMES_END = 0x26f9fc
+    NAME_SIZE = 10
+
+    ABILITY_DATA_START = 0x0471ea
+    ABILITY_DATA_END = 0x047259
+
+    # These 8 bytes control the Magitek that Terra can use
+    TERRA_MAGITEK_ATTACKS_START = 0x1910C
+    TERRA_MAGITEK_ATTACKS_END = 0x19113
+    # These 8 bytes control the Magitek that other characters can use
+    OTHER_CHAR_MAGITEK_ATTACKS_START = 0x19114
+    OTHER_CHAR_MAGITEK_ATTACKS_END = 0x1911B
+    MAGITEK_ATTACKS_SIZE = 1
+
+    def __init__(self, rom, args):
+        self.rom = rom
+        self.args = args
+
+        self.name_data = DataArray(self.rom, self.NAMES_START, self.NAMES_END, self.NAME_SIZE)
+        self.ability_data = DataArray(self.rom, self.ABILITY_DATA_START, self.ABILITY_DATA_END, AbilityData.DATA_SIZE)
+        self.other_char_magitek_attacks = DataArray(self.rom, self.OTHER_CHAR_MAGITEK_ATTACKS_START, self.OTHER_CHAR_MAGITEK_ATTACKS_END, self.MAGITEK_ATTACKS_SIZE)
+
+        self.magiteks = []
+        for magitek_index in range(len(self.ability_data)):
+            magitek = Magitek(magitek_index, self.name_data[magitek_index], self.ability_data[magitek_index])
+            self.magiteks.append(magitek)
+
+    def fix_reflectable_beams(self):
+        # Set the Fire/Bolt/Ice beams to ignore reflect to avoid graphical glitches
+        self.magiteks[self.FIRE_BEAM].flags2 = 0x22
+        self.magiteks[self.BOLT_BEAM].flags2 = 0x22
+        self.magiteks[self.ICE_BEAM].flags2 = 0x22
+
+    def give_all_magiteks(self):
+        # Give all magitek abilities to every character, not just Terra
+        # FF = disabled
+        # 0 = Fire Beam, ... 7 = TekMissile
+        self.other_char_magitek_attacks[self.BIO_BLAST] = self.BIO_BLAST.to_bytes(1, 'little')
+        self.other_char_magitek_attacks[self.CONFUSER] = self.CONFUSER.to_bytes(1, 'little')
+        self.other_char_magitek_attacks[self.X_FER] = self.X_FER.to_bytes(1, 'little')
+        self.other_char_magitek_attacks[self.TEKMISSILE] = self.TEKMISSILE.to_bytes(1, 'little')
+
+    def mod(self):
+        self.fix_reflectable_beams()
+        self.give_all_magiteks()
+        pass
+
+    def write(self):
+        if self.args.spoiler_log:
+            self.log()
+
+        for magitek_index, magitek in enumerate(self.magiteks):
+            self.name_data[magitek_index] = magitek.name_data()
+            self.ability_data[magitek_index] = magitek.ability_data()
+
+        self.name_data.write()
+        self.ability_data.write()
+        self.other_char_magitek_attacks.write()
+
+    def log(self):
+        pass
+
+    def print(self):
+        for magitek in self.magiteks:
+            magitek.print()


### PR DESCRIPTION
**Overview**

This Pull Request is designed to add Magitek as a valid command for FF6WC. Changes include:

- Removing Magitek from the Always-excluded list of commands
- Fixing the Magitek reflect bug, documented here: http://assassin17.brinkster.net/patches.htm#anchor40
- Giving all characters every Magitek, by modifying this list to match Terra's: https://github.com/clementgallet/ff6-tas/blob/master/DisassemblyDocs/Bank%20C1%20disassembly.txt#L18568
- Adding a Random Exclude Command 6 option, so that those who don't enjoy fun (albeit OP) things can disable Magitek and 5 other commands.

The implementation of magiteks.py was modeled after espers.py (for example, phoenix_life3) and lores.py.

**Testing Notes**

_Hex Compares_

Before this change, this is the hex for the magiteks available (note the FFs)
![magiteks_available_before](https://user-images.githubusercontent.com/96998881/150691906-b71fbbc6-c54b-4f88-a217-f2fc7471c2dc.PNG)

After this change, this is the hex for the magiteks available (note no FFs)
![magiteks_available_after](https://user-images.githubusercontent.com/96998881/150691924-4d60addc-198e-4dca-b1ec-d0d4654468f1.PNG)

And here's the hex for the Magitek Abilities (ref: https://www.ff6hacking.com/wiki/doku.php?id=ff3:ff3us:doc:asm:fmt:spell_data) before the change:
![magitek_ability_data](https://user-images.githubusercontent.com/96998881/150692085-c597e63e-07e8-45c8-8e35-2f383ba79ab8.PNG)

And here's the hex for the Magitek Abilities with the Special Flags 2 set to 0x22 ("Ignore reflect" set to 1):
![magitek_ability_data_with_fix](https://user-images.githubusercontent.com/96998881/150692126-fcb581a1-3a6a-48d7-bc3d-7db8aeb3f3b7.PNG)

_Play Testing_

Play Testing was performed with the following flags: `wc.py -com 29299898989898989898989898 -sc1 Terra -sc2 Locke -as`

To test the Magitek Reflect bug, first a test was performed without the patch in which Leafers and Dark Winds were given the Reflect status using FF3usME). A video of the results is here:
https://youtu.be/8RCbWPdiO8Y

Then, following the patch, here's a video showing no reflect bug (again, Leafers and Dark Winds were given the Reflect status using FF3usME). A video of the results is here:
https://youtu.be/k--nohPVmjY

Finally, wc.py -h was checked to ensure that -rec6 shows up. That flag was also checked in the menu (using -rec6 29):
![random_exclude_6_magitek](https://user-images.githubusercontent.com/96998881/150692311-4ebd05ff-1f45-4e75-b98c-8d5ba0c2fc5a.PNG)

