### PR TITLE
Bugfix: Max stats added by objectives at 128

### DIFF
--- a/objectives/results/_add_sub_stat.py
+++ b/objectives/results/_add_sub_stat.py
@@ -5,16 +5,13 @@ import instruction.field as field
 from objectives.results._apply_characters_party import ApplyToCharacter, ApplyToCharacters
 
 def AddStat(stat_address):
+    MAX_STAT = 0x80
     return [
         asm.LDA(stat_address, asm.ABS_Y),
-        asm.CLC(),
         asm.ADC(field.LongCall.ARG_ADDRESS, asm.DIR),
-        asm.BCS("MAXIMUM"),
-        asm.BRA("STORE"),
-
-        "MAXIMUM",
-        asm.LDA(255, asm.IMM8),
-
+        asm.CMP(MAX_STAT, asm.IMM8),
+        asm.BLT("STORE"),             # If < 128, skip to STORE
+        asm.LDA(MAX_STAT, asm.IMM8),  # Else, cap at 128
         "STORE",
         asm.STA(stat_address, asm.ABS_Y),
     ]

--- a/objectives/results/_add_sub_stat.py
+++ b/objectives/results/_add_sub_stat.py
@@ -8,6 +8,7 @@ def AddStat(stat_address):
     MAX_STAT = 0x80
     return [
         asm.LDA(stat_address, asm.ABS_Y),
+        asm.CLC(),
         asm.ADC(field.LongCall.ARG_ADDRESS, asm.DIR),
         asm.CMP(MAX_STAT, asm.IMM8),
         asm.BLT("STORE"),             # If < 128, skip to STORE


### PR DESCRIPTION
Tested with seed with these flags:
`py wc.py -i ../rom/ff3.sfc -oa 45.99.99.0.0 -ob 48.99.99.0.0 -oc 46.99.99.0.0 -od 47.99.99.0.0 -sc1 relm -sc2 locke -sc3 cyan -sc4 umaro -com 26069898982998989898989898 -lsa 1 -hmced 0.5 -as -frw -mca -smc 3 -sn`

(Note: -sn was used because items like Relm's default Chocobo Brush can cause stats to go above 128.)

Resulting stats:
![plus99_cyan](https://user-images.githubusercontent.com/96998881/153783639-9c0a0eb6-d935-46b1-86d8-776c27e57481.PNG)
Cyan's defaults: 40, 28, 33, 25
![plus99_relm](https://user-images.githubusercontent.com/96998881/153783646-3111ca04-b3e5-4738-a28c-7101b19b994b.PNG)
Relm's defaults: 26, 34, 22, 44
![plus99_locke](https://user-images.githubusercontent.com/96998881/153783652-e8f45b9a-7087-432d-8d5a-062b1ba9806a.PNG)
Locke's defaults: 37, 40, 31, 28
![plus99_umaro](https://user-images.githubusercontent.com/96998881/153783653-961694e2-9401-4364-a7a5-e0a8b64b6d2e.PNG)
Umaro's defaults: 57, 33, 46, 37

