### PR TITLE
Feature: Removing more flashes from flash_remove_most

### DIFF
--- a/battle/animations.py
+++ b/battle/animations.py
@@ -10,6 +10,8 @@ class Animations:
         if args.flashes_remove_most:
             flash_address_arrays = battle_animation_scripts.BATTLE_ANIMATION_FLASHES.values()
             self.remove_battle_flashes_mod(flash_address_arrays)
+            self.remove_critical_flash()
+
         if args.flashes_remove_worst:
             flash_address_arrays = []
             animation_names = ["Boss Death", "Ice 3", "Fire 3", "Bolt 3", "Schiller", "R.Polarity", "X-Zone",
@@ -18,6 +20,9 @@ class Animations:
             for name in animation_names:
                 flash_address_arrays.append(battle_animation_scripts.BATTLE_ANIMATION_FLASHES[name])
             self.remove_battle_flashes_mod(flash_address_arrays)
+
+    def remove_critical_flash(self):
+        space = Reserve(0x23410, 0x23413, "Critical hit screen flash", asm.NOP())
 
     def remove_battle_flashes_mod(self, flash_address_arrays):
         ABSOLUTE_CHANGES = [0xb0, 0xaf]

--- a/event/collapsing_house.py
+++ b/event/collapsing_house.py
@@ -22,6 +22,8 @@ class CollapsingHouse(Event):
 
         if self.args.character_gating:
             self.add_gating_condition()
+        if self.args.flashes_remove_most:
+            self.flash_mod()
 
         if self.reward.type == RewardType.CHARACTER:
             self.character_mod(self.reward.id)
@@ -61,6 +63,13 @@ class CollapsingHouse(Event):
         space = Reserve(0xc5a45, 0xc5a47, "collapsing house end of world dialog", field.NOP())
         space = Reserve(0xc5a55, 0xc5a6b, "collapsing house given up hope dialog", field.NOP())
         space = Reserve(0xc5a79, 0xc5a7c, "collapsing house smash kefka dialog", field.NOP())
+
+    def flash_mod(self):
+        space = Reserve(0xc5848, 0xc5849, "collapsing house initial flash 1", field.NOP())
+        space = Reserve(0xc5863, 0xc5864, "collapsing house initial flash 2", field.NOP())
+        space = Reserve(0xc5868, 0xc5869, "collapsing house initial flash 3", field.NOP())
+        space = Reserve(0xc59ec, 0xc59ed, "collapsing house final flash 1", field.NOP())
+        space = Reserve(0xc59f5, 0xc59f6, "collapsing house final flash 2", field.NOP())
 
     def add_gating_condition(self):
         start_event = 0xc5844

--- a/event/doma_wor.py
+++ b/event/doma_wor.py
@@ -165,6 +165,11 @@ class DomaWOR(Event):
             field.Branch(space.end_address + 1), # skip nops
         )
 
+        if(self.args.flashes_remove_most):
+            space = Reserve(0xb9952, 0xb9953, "doma wor sword appears flash 1", field.NOP())
+            space = Reserve(0xb9975, 0xb9976, "doma wor sword appears flashes", field.NOP())
+            space = Reserve(0xb99a9, 0xb99aa, "doma wor sword appears flash 3", field.NOP())
+
         space = Reserve(0xb997d, 0xb9984, "doma wor cyan kneeling", field.NOP())
         space = Reserve(0xb99df, 0xb99e0, "doma wor pause before loading room slept in", field.NOP())
         space = Reserve(0xb99f6, 0xb99fa, "doma wor animate party knocked out", field.NOP())
@@ -257,6 +262,9 @@ class DomaWOR(Event):
         )
 
     def finish_dream_awaken_mod(self):
+        if(self.args.flashes_remove_most):
+            space = Reserve(0xb9a47, 0xb9a48, "doma wor peak swordmanship flash", field.NOP())
+
         src = [
             field.FinishCheck(),
             field.Return(),
@@ -270,6 +278,8 @@ class DomaWOR(Event):
         )
 
         space = Reserve(0xb9a6f, 0xb9a6f, "doma wor learn all swdtechs", field.NOP())
+
+
 
     def throne_esper_item_mod(self, reward_instructions):
         src = [

--- a/event/magitek_factory.py
+++ b/event/magitek_factory.py
@@ -104,8 +104,11 @@ class MagitekFactory(Event):
         space = Reserve(0xc7998, 0xc799a, "magitek factory they drained our powers", field.NOP())
 
         space = Reserve(0xc79a4, 0xc79cf, "magitek factory ifrit/shiva magicite", field.NOP())
-        space.write(
-            field.FlashScreen(field.Flash.WHITE),
+        src = []
+        if not self.args.flashes_remove_most:
+            src.append(field.FlashScreen(field.Flash.WHITE))
+
+        src.append([
             field.PlaySoundEffect(80),
             field.HideEntity(ifrit_npc_id),
             field.HideEntity(shiva_npc_id),
@@ -118,7 +121,8 @@ class MagitekFactory(Event):
             field.SetEventBit(event_bit.GOT_IFRIT_SHIVA),
             field.FinishCheck(),
             field.Return(),
-        )
+        ])
+        space.write(src)
 
     def ifrit_shiva_esper_mod(self, esper):
         self.ifrit_shiva_mod([

--- a/event/owzer_mansion.py
+++ b/event/owzer_mansion.py
@@ -16,6 +16,9 @@ class OwzerMansion(Event):
 
         self.dialog_mod()
 
+        if(self.args.flashes_remove_most):
+            self.flash_mod()
+
         if self.args.character_gating:
             self.add_gating_condition()
 
@@ -37,6 +40,9 @@ class OwzerMansion(Event):
         self.finish_check_mod()
 
         self.log_reward(self.reward)
+
+    def flash_mod(self):
+        space = Reserve(0xb4d10, 0xb4d11, "owzer mansion flash", field.NOP())
 
     def dialog_mod(self):
         space = Reserve(0xb4d0d, 0xb4d0f, "owzer mansion help that painting!!", field.NOP())


### PR DESCRIPTION
Removing more screen flashes for -frm flag.

Battle flashes:
1) Critical hit. Tested by equipping Rag and Fighting until out of MP. Noted 2x damage while I still had enough MP, but no screen flashes.

Events affected:
1) Owzer Mansion right before fighting boss
2) Doma WoR after last boss and after awaking
3) Collapsing House - entering town and during collapse
4) When collecting Ifrit/Shiva Magicite

Tested by running the checks for each event and noting no more screen flashes where expected.