### PR TITLE
Adding Controllable Coliseum flag

### DIFF
--- a/args/coliseum.py
+++ b/args/coliseum.py
@@ -29,6 +29,9 @@ def parse(parser):
     coliseum.add_argument("-cnil", "--coliseum-no-illuminas", action = "store_true",
                        help = "Illuminas will not appear in coliseum")
 
+    coliseum.add_argument("-cc", "--coliseum-controllable", action = "store_true",
+                       help = "Make characters controllable in coliseum (except Umaro)")
+
 def process(args):
     args._process_min_max("coliseum_rewards_visible_random")
 
@@ -55,6 +58,9 @@ def flags(args):
         flags += " -cnee"
     if args.coliseum_no_illuminas:
         flags += " -cnil"
+
+    if args.coliseum_controllable:
+        flags += " -cc"
 
     return flags
 
@@ -84,6 +90,7 @@ def options(args):
         ("Rewards Menu", args.coliseum_rewards_menu),
         ("No Exp. Eggs", args.coliseum_no_exp_eggs),
         ("No Illuminas", args.coliseum_no_illuminas),
+        ("Controllable", args.coliseum_controllable),
     ]
 
 def menu(args):

--- a/data/coliseum.py
+++ b/data/coliseum.py
@@ -75,6 +75,15 @@ class Coliseum():
         for match_index in hidden_indices:
             self.matches[match_index].reward_hidden = 1
 
+    def controllable(self):
+        # Replacing these commands from vanilla with NO-OPS to make Coliseum battles controllable:
+        # C2/092F: AD 97 3A     LDA $3A97      (RAM $3A97 = character are on auto-pilot [colosseum])
+        # C2/0932: D0 91        BNE $08C5      (exit if in the Colosseum)
+        from memory.space import Reserve
+        import instruction.asm as asm
+
+        space = Reserve(0x02092f, 0x020933, "removing Coliseum check for commands", asm.NOP())
+
     def mod(self):
         if self.args.coliseum_opponents_shuffle:
             self.shuffle_opponents()
@@ -90,6 +99,9 @@ class Coliseum():
 
         if self.args.coliseum_rewards_visible_random:
             self.randomize_rewards_hidden()
+
+        if self.args.coliseum_controllable:
+            self.controllable()
 
     def log(self):
         from log import section


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/96998881/155650136-2beb0647-1db2-4ad7-9513-9eb23c277bb0.png)

Coliseum battles are now controllable with the -cc flag. Confirmed that everything still works with coliseum: winning, losing, and Umaro is still Umaro.

Inspired by https://www.romhacking.net/hacks/1099/, although I opted to just NO-OP the LDA and BNE.