### PR TITLE
Feature: Flashes: Moving flashes to Graphics; Slowing scrolling background during Air Force fight and Baren falls; add minimap high contrast option

### DIFF
--- a/args/graphics.py
+++ b/args/graphics.py
@@ -10,6 +10,13 @@ def parse(parser):
     graphics.add_argument("-cspr", "--character-sprites", type = str, help = "Character sprite indices")
     graphics.add_argument("-cspp", "--character-sprite-palettes", type = str, help = "Character sprite palette indices")
 
+    remove_flashes = graphics.add_mutually_exclusive_group()
+    remove_flashes.add_argument("-frw", "--flashes-remove-worst", action = "store_true",
+                              help = "Removes only the worst flashes from animations. Ex: Learning Bum Rush, Bum Rush, Quadra Slam/Slice, Flash, etc.")
+    remove_flashes.add_argument("-frm", "--flashes-remove-most", action = "store_true",
+                              help = "Removes most flashes from animations. Includes Kefka Death.")
+
+
 def process(args):
     import graphics.palettes.palettes as palettes
     import graphics.portraits.portraits as portraits
@@ -98,6 +105,11 @@ def flags(args):
     if args.character_sprite_palettes:
         flags += " -cspp " + args.character_sprite_palettes
 
+    if args.flashes_remove_worst:
+        flags += " -frw"
+    if args.flashes_remove_most:
+        flags += " -frm"
+
     return flags
 
 def _truncated_name(name):
@@ -148,12 +160,34 @@ def _character_customization_log(args):
 
     return log
 
+def _other_options_log(args):
+    from log import format_option
+    log = ["Other Graphics"]
+
+    remove_flashes = "Original"
+    if args.flashes_remove_worst:
+        remove_flashes = "Worst"
+    elif args.flashes_remove_most:
+        remove_flashes = "Most"
+
+    entries = [
+        ("Remove Flashes", remove_flashes),
+    ]
+
+    for entry in entries:
+        log.append(format_option(*entry))
+
+    return log
+
 def log(args):
     lcolumn = [""]
     lcolumn.extend(_sprite_palettes_log(args))
 
     lcolumn.append("")
     lcolumn.extend(_other_portraits_sprites_log(args))
+
+    lcolumn.append("")
+    lcolumn.extend(_other_options_log(args))
 
     rcolumn = [""]
     rcolumn.extend(_character_customization_log(args))

--- a/args/graphics.py
+++ b/args/graphics.py
@@ -16,6 +16,8 @@ def parse(parser):
     remove_flashes.add_argument("-frm", "--flashes-remove-most", action = "store_true",
                               help = "Removes most flashes from animations. Includes Kefka Death.")
 
+    graphics.add_argument("-wmhc", "--world-minimap-high-contrast", action = "store_true",
+                              help = "World Minimap made Opaque with Minimap icon changed to higher contrast to improve visibility.")
 
 def process(args):
     import graphics.palettes.palettes as palettes
@@ -109,7 +111,8 @@ def flags(args):
         flags += " -frw"
     if args.flashes_remove_most:
         flags += " -frm"
-
+    if args.world_minimap_high_contrast:
+        flags += " -wmhc"
     return flags
 
 def _truncated_name(name):
@@ -170,8 +173,13 @@ def _other_options_log(args):
     elif args.flashes_remove_most:
         remove_flashes = "Most"
 
+    world_minimap = "Original"
+    if args.world_minimap_high_contrast:
+        world_minimap = "High Contrast"
+
     entries = [
         ("Remove Flashes", remove_flashes),
+        ("World Minimap", world_minimap),
     ]
 
     for entry in entries:

--- a/args/misc.py
+++ b/args/misc.py
@@ -43,12 +43,6 @@ def parse(parser):
                        help = "Remove NPC")
     parser.y_npc_group = y_npc
 
-    remove_flashes = misc.add_mutually_exclusive_group()
-    remove_flashes.add_argument("-frw", "--flashes-remove-worst", action = "store_true",
-                              help = "Removes only the worst flashes from animations. Ex: Learning Bum Rush, Bum Rush, Quadra Slam/Slice, Flash, etc.")
-    remove_flashes.add_argument("-frm", "--flashes-remove-most", action = "store_true",
-                              help = "Removes most flashes from animations. Includes Kefka Death.")
-
 def process(args):
     args.y_npc = False # are any y_npc flags enabled?
 
@@ -98,11 +92,6 @@ def flags(args):
     elif args.y_npc_remove:
         flags += " -yremove"
 
-    if args.flashes_remove_worst:
-        flags += " -frw"
-    if args.flashes_remove_most:
-        flags += " -frm"
-
     return flags
 
 def options(args):
@@ -134,12 +123,6 @@ def options(args):
     elif args.y_npc_remove:
         y_npc = "Remove"
 
-    remove_flashes = "Original"
-    if args.flashes_remove_worst:
-        remove_flashes = "Worst"
-    elif args.flashes_remove_most:
-        remove_flashes = "Most"
-
     return [
         ("Auto Sprint", args.auto_sprint),
         ("Original Name Display", args.original_name_display),
@@ -148,7 +131,6 @@ def options(args):
         ("Scan All", args.scan_all),
         ("Event Timers", event_timers),
         ("Y NPC", y_npc),
-        ("Remove Flashes", remove_flashes)
     ]
 
 def menu(args):

--- a/battle/animations.py
+++ b/battle/animations.py
@@ -7,22 +7,53 @@ class Animations:
     def __init__(self):
         self.health_animation_reflect_mod()
 
-        if args.flashes_remove_most:
-            flash_address_arrays = battle_animation_scripts.BATTLE_ANIMATION_FLASHES.values()
-            self.remove_battle_flashes_mod(flash_address_arrays)
-            self.remove_critical_flash()
+        # Flash removal
+        replace_flash_animation = [] # The background flash to replace with monster flashes
+        remove_flash_animation = [] # The background flash addresses to remove
 
-        if args.flashes_remove_worst:
-            flash_address_arrays = []
-            animation_names = ["Boss Death", "Ice 3", "Fire 3", "Bolt 3", "Schiller", "R.Polarity", "X-Zone",
+        if args.flashes_remove_most:
+            # Replace Boss Death and Final Kefka
+            replace_flash_animation.extend(["Boss Death", "Final KEFKA Death"])
+            # And remove the rest
+            remove_flash_animation.extend(battle_animation_scripts.BATTLE_ANIMATION_FLASHES.keys())
+            # Also removing critical flash
+            self.remove_critical_flash()
+        elif args.flashes_remove_worst:
+            replace_flash_animation.extend(["Boss Death"])
+            remove_flash_animation.extend(["Ice 3", "Fire 3", "Bolt 3", "Schiller", "R.Polarity", "X-Zone",
                                "Muddle", "Dispel", "Shock", "Bum Rush", "Quadra Slam", "Slash", "Flash", 
-                               "Step Mine", "Rippler", "WallChange", "Ultima", "ForceField"]
-            for name in animation_names:
-                flash_address_arrays.append(battle_animation_scripts.BATTLE_ANIMATION_FLASHES[name])
+                               "Step Mine", "Rippler", "WallChange", "Ultima", "ForceField"])
+
+        # Replace any specified above
+        flash_address_arrays = [battle_animation_scripts.BATTLE_ANIMATION_FLASHES[name] for name in replace_flash_animation]
+        if flash_address_arrays:
+            self.replace_bg_flash_with_monster_flash_mod(flash_address_arrays)
+        
+        # Remove any remainder specified above
+        flash_address_arrays = [battle_animation_scripts.BATTLE_ANIMATION_FLASHES[name] for name in remove_flash_animation if name not in replace_flash_animation]
+        if flash_address_arrays:
             self.remove_battle_flashes_mod(flash_address_arrays)
 
     def remove_critical_flash(self):
         space = Reserve(0x23410, 0x23413, "Critical hit screen flash", asm.NOP())
+
+    def replace_bg_flash_with_monster_flash_mod(self, flash_address_arrays):
+        REPLACEMENTS = {
+            0xAF: 0xB9, # Set background palette color subtraction (absolute) -> Set monster palettes color subtraction (absolute)
+            0xB0: 0xBA, # Set background palette color addition (absolute) -> Set monster palettes color addition (absolute)
+            0xB5: 0xBB, # Add color to background palette (relative) -> Add color to monster palettes (relative)
+            0xB6: 0xBC, # Subtract color from background palette (relative) -> Subtract color from monster palettes (relative)
+        }
+        for flash_addresses in flash_address_arrays:
+            # For each address in its array
+            for flash_address in flash_addresses:
+                # Read the current animation command at the address
+                animation_cmd = Read(flash_address, flash_address+1)
+                if(animation_cmd[0] in REPLACEMENTS.keys()):
+                    Write(flash_address, REPLACEMENTS[animation_cmd[0]], "BG flash to monster flash")
+                else:
+                    # This is an error, reflecting a difference between the disassembly used to generate BATTLE_ANIMATION_FLASHES and the ROM
+                    raise ValueError(f"Battle Animation Script Command at 0x{flash_address:x} (0x{animation_cmd[0]:x}) did not match an expected value.")
 
     def remove_battle_flashes_mod(self, flash_address_arrays):
         ABSOLUTE_CHANGES = [0xb0, 0xaf]

--- a/data/maps.py
+++ b/data/maps.py
@@ -12,6 +12,7 @@ import data.map_exits as exits
 from data.map_exit import ShortMapExit, LongMapExit
 
 import data.world_map_event_modifications as world_map_event_modifications
+from data.world_map import WorldMap
 
 class Maps():
     MAP_COUNT = 416
@@ -33,6 +34,7 @@ class Maps():
         self.events = events.MapEvents(rom)
         self.exits = exits.MapExits(rom)
         self.world_map_event_modifications = world_map_event_modifications.WorldMapEventModifications(rom)
+        self.world_map = WorldMap(rom, args)
         self.read()
 
     def read(self):
@@ -189,6 +191,7 @@ class Maps():
     def mod(self, characters):
         self.npcs.mod(characters)
         self.chests.mod()
+        self.world_map.mod()
 
         self._fix_imperial_camp_boxes()
 

--- a/data/world_map.py
+++ b/data/world_map.py
@@ -6,25 +6,50 @@ class WorldMap:
         self.args = args
 
     def world_minimap_high_contrast_mod(self):
+        # Thanks to Osteoclave for identifying these changes
+
         # Increases the sprite priority for the minimap sprites
         # So it gets drawn on top of the overworld instead of being translucent
-        # Thanks to Osteoclave for identifying these changes
-        # Colors bytes: gggrrrrr, xbbbbbgg
-        space = Reserve(0x2e4146, 0x2e4146, "steal value constant")
+        #ee4146=1b
+        space = Reserve(0x2e4146, 0x2e4146, "minimap sprite priority")
         space.write(0x1b) # default: 0x0b
 
+        # Colors bytes: gggrrrrr, xbbbbbgg
         # High contrast location indicator on minimaps
+        # d2eeb8=ff + d2eeb9=7f
+        # d2efb8=ff + d2efb9=7f
         location_indicator_addr = [0x12eeb8,  # WoB default: 1100
                                    0x12efb8]  # WoR default: 1100
         for loc_addr in location_indicator_addr:
             space = Reserve(loc_addr, loc_addr+1, "high contrast minimap indicator")
-            space.write(0xff, 0x03) # yellow
+            space.write(0xff, 0x7f)
 
+        # d2eeba=ff + d2eebb=7f
+        # d2efba=ff + d2efbb=7f
         location_indicator_addr = [0x12eeba,  # WoB default: 1f00
                                    0x12efba]  # WoR default: 1f00
         for loc_addr in location_indicator_addr:
             space = Reserve(loc_addr, loc_addr+1, "high contrast minimap indicator")
-            space.write(0x00, 0x7F) # teal
+            space.write(0xff, 0x7f) 
+
+        # Additional minimap palette mods
+        # default: 84 10 e7 1c 4a 29 10 42 ff 7f
+        # WoB: d2eea2=00 + d2eea3=14 + d2eea4=82 + d2eea5=28 + d2eea6=e4 + d2eea7=38 + d2eea8=67 + d2eea9=51 + d2eeaa=9c + d2eeab=02
+        # WoR: d2efa2=00 + d2efa3=14 + d2efa4=82 + d2efa5=28 + d2efa6=e4 + d2efa7=38 + d2efa8=67 + d2efa9=51 + d2efaa=9c + d2efab=02
+        minimap_palette_bytes = [0x00, 0x14, 0x82, 0x28, 0xe4, 0x38, 0x67, 0x51, 0x9c, 0x02]
+        minimap_palette_addr = [0x12eea2, # WoB
+                                0x12efa2] # WoR
+        for addr in minimap_palette_addr:
+            space = Reserve(addr, addr+len(minimap_palette_bytes)-1, "minimap palette")
+            space.write(minimap_palette_bytes)
+
+        # This changes the color of the Floating Continent (pre-floating) on WoB
+        # default: e7 1c 4a 29 10 42
+        # d2eeac=82 + d2eead=28 + d2eeae=e4 + d2eeaf=38 + d2eeb0=67 + d2eeb1=51
+        addr = 0x12eeac
+        minimap_palette_bytes = [0x82, 0x28, 0xe4, 0x38, 0x67, 0x51]
+        space = Reserve(addr, addr+len(minimap_palette_bytes)-1, "floating continent palette")
+        space.write(minimap_palette_bytes)
 
     def mod(self):
         if self.args.world_minimap_high_contrast:

--- a/data/world_map.py
+++ b/data/world_map.py
@@ -8,6 +8,8 @@ class WorldMap:
     def world_minimap_high_contrast_mod(self):
         # Increases the sprite priority for the minimap sprites
         # So it gets drawn on top of the overworld instead of being translucent
+        # Thanks to Osteoclave for identifying these changes
+        # Colors bytes: gggrrrrr, xbbbbbgg
         space = Reserve(0x2e4146, 0x2e4146, "steal value constant")
         space.write(0x1b) # default: 0x0b
 
@@ -16,13 +18,13 @@ class WorldMap:
                                    0x12efb8]  # WoR default: 1100
         for loc_addr in location_indicator_addr:
             space = Reserve(loc_addr, loc_addr+1, "high contrast minimap indicator")
-            space.write(0x1f, 0x00) # red
+            space.write(0xff, 0x03) # yellow
 
         location_indicator_addr = [0x12eeba,  # WoB default: 1f00
                                    0x12efba]  # WoR default: 1f00
         for loc_addr in location_indicator_addr:
             space = Reserve(loc_addr, loc_addr+1, "high contrast minimap indicator")
-            space.write(0xff, 0x03) # yellow
+            space.write(0x00, 0x7F) # teal
 
     def mod(self):
         if self.args.world_minimap_high_contrast:

--- a/data/world_map.py
+++ b/data/world_map.py
@@ -13,12 +13,16 @@ class WorldMap:
 
         # High contrast location indicator on minimaps
         location_indicator_addr = [0x12eeb8,  # WoB default: 1100
-                                   0x12eeba,  # WoB default: 1f00
-                                   0x12efb8,  # WoR default: 1100
+                                   0x12efb8]  # WoR default: 1100
+        for loc_addr in location_indicator_addr:
+            space = Reserve(loc_addr, loc_addr+1, "high contrast minimap indicator")
+            space.write(0x1f, 0x00) # red
+
+        location_indicator_addr = [0x12eeba,  # WoB default: 1f00
                                    0x12efba]  # WoR default: 1f00
         for loc_addr in location_indicator_addr:
             space = Reserve(loc_addr, loc_addr+1, "high contrast minimap indicator")
-            space.write(0x7f, 0xff)
+            space.write(0xff, 0x03) # yellow
 
     def mod(self):
         if self.args.world_minimap_high_contrast:

--- a/data/world_map.py
+++ b/data/world_map.py
@@ -1,0 +1,25 @@
+from memory.space import Reserve
+
+class WorldMap:
+    def __init__(self, rom, args):
+        self.rom = rom
+        self.args = args
+
+    def world_minimap_high_contrast_mod(self):
+        # Increases the sprite priority for the minimap sprites
+        # So it gets drawn on top of the overworld instead of being translucent
+        space = Reserve(0x2e4146, 0x2e4146, "steal value constant")
+        space.write(0x1b) # default: 0x0b
+
+        # High contrast location indicator on minimaps
+        location_indicator_addr = [0x12eeb8,  # WoB default: 1100
+                                   0x12eeba,  # WoB default: 1f00
+                                   0x12efb8,  # WoR default: 1100
+                                   0x12efba]  # WoR default: 1f00
+        for loc_addr in location_indicator_addr:
+            space = Reserve(loc_addr, loc_addr+1, "high contrast minimap indicator")
+            space.write(0x7f, 0xff)
+
+    def mod(self):
+        if self.args.world_minimap_high_contrast:
+            self.world_minimap_high_contrast_mod()

--- a/event/baren_falls.py
+++ b/event/baren_falls.py
@@ -172,7 +172,7 @@ class BarenFalls(Event):
         )
 
         # Eliminate the palette swaps without reducing any cpu cycles by just writing back the value from the previous LDA
-        space = Reserve(0x2b20b, 0x2b30d, "waterfall palette change")
+        space = Reserve(0x2b20b, 0x2b20d, "waterfall palette change")
         space.write(
             asm.STA(0xEC71, asm.ABS_X)
         )

--- a/event/baren_falls.py
+++ b/event/baren_falls.py
@@ -22,6 +22,9 @@ class BarenFalls(Event):
         self.after_battle_mod()
         self.already_complete_mod()
 
+        if self.args.flashes_remove_most:
+            self.background_scrolling_mod()
+
         if self.reward.type == RewardType.CHARACTER:
             self.character_mod(self.reward.id)
         elif self.reward.type == RewardType.ESPER:
@@ -160,3 +163,10 @@ class BarenFalls(Event):
             field.AddItem(item),
             field.Dialog(self.items.get_receive_dialog(item)),
         ])
+
+    def background_scrolling_mod(self):
+        # Slow the scrolling background by modifying the ADC command.
+        space = Reserve(0x2b1f7, 0x2b1f9, "waterfall background movement")
+        space.write(
+            asm.ADC(0x0001, asm.IMM16) #default: 0x0006
+        )

--- a/event/baren_falls.py
+++ b/event/baren_falls.py
@@ -170,3 +170,9 @@ class BarenFalls(Event):
         space.write(
             asm.ADC(0x0001, asm.IMM16) #default: 0x0006
         )
+
+        # Eliminate the palette swaps without reducing any cpu cycles by just writing back the value from the previous LDA
+        space = Reserve(0x2b20b, 0x2b30d, "waterfall palette change")
+        space.write(
+            asm.STA(0xEC71, asm.ABS_X)
+        )

--- a/event/collapsing_house.py
+++ b/event/collapsing_house.py
@@ -22,7 +22,7 @@ class CollapsingHouse(Event):
 
         if self.args.character_gating:
             self.add_gating_condition()
-        if self.args.flashes_remove_most:
+        if self.args.flashes_remove_most or self.args.flashes_remove_worst:
             self.flash_mod()
 
         if self.reward.type == RewardType.CHARACTER:

--- a/event/collapsing_house.py
+++ b/event/collapsing_house.py
@@ -65,11 +65,11 @@ class CollapsingHouse(Event):
         space = Reserve(0xc5a79, 0xc5a7c, "collapsing house smash kefka dialog", field.NOP())
 
     def flash_mod(self):
-        space = Reserve(0xc5848, 0xc5849, "collapsing house initial flash 1", field.NOP())
-        space = Reserve(0xc5863, 0xc5864, "collapsing house initial flash 2", field.NOP())
-        space = Reserve(0xc5868, 0xc5869, "collapsing house initial flash 3", field.NOP())
-        space = Reserve(0xc59ec, 0xc59ed, "collapsing house final flash 1", field.NOP())
-        space = Reserve(0xc59f5, 0xc59f6, "collapsing house final flash 2", field.NOP())
+        space = Reserve(0xc5848, 0xc5849, "collapsing house initial flash 1", field.FlashScreen(field.Flash.NONE))
+        space = Reserve(0xc5863, 0xc5864, "collapsing house initial flash 2", field.FlashScreen(field.Flash.NONE))
+        space = Reserve(0xc5868, 0xc5869, "collapsing house initial flash 3", field.FlashScreen(field.Flash.NONE))
+        space = Reserve(0xc59ec, 0xc59ed, "collapsing house final flash 1", field.FlashScreen(field.Flash.NONE))
+        space = Reserve(0xc59f5, 0xc59f6, "collapsing house final flash 2", field.FlashScreen(field.Flash.NONE))
 
     def add_gating_condition(self):
         start_event = 0xc5844

--- a/event/doma_wor.py
+++ b/event/doma_wor.py
@@ -166,9 +166,9 @@ class DomaWOR(Event):
         )
 
         if(self.args.flashes_remove_most):
-            space = Reserve(0xb9952, 0xb9953, "doma wor sword appears flash 1", field.NOP())
-            space = Reserve(0xb9975, 0xb9976, "doma wor sword appears flashes", field.NOP())
-            space = Reserve(0xb99a9, 0xb99aa, "doma wor sword appears flash 3", field.NOP())
+            space = Reserve(0xb9952, 0xb9953, "doma wor sword appears flash 1", field.FlashScreen(field.Flash.NONE))
+            space = Reserve(0xb9975, 0xb9976, "doma wor sword appears flashes", field.FlashScreen(field.Flash.NONE))
+            space = Reserve(0xb99a9, 0xb99aa, "doma wor sword appears flash 3", field.FlashScreen(field.Flash.NONE))
 
         space = Reserve(0xb997d, 0xb9984, "doma wor cyan kneeling", field.NOP())
         space = Reserve(0xb99df, 0xb99e0, "doma wor pause before loading room slept in", field.NOP())
@@ -263,7 +263,7 @@ class DomaWOR(Event):
 
     def finish_dream_awaken_mod(self):
         if(self.args.flashes_remove_most):
-            space = Reserve(0xb9a47, 0xb9a48, "doma wor peak swordmanship flash", field.NOP())
+            space = Reserve(0xb9a47, 0xb9a48, "doma wor peak swordmanship flash", field.FlashScreen(field.Flash.NONE))
 
         src = [
             field.FinishCheck(),

--- a/event/doma_wor.py
+++ b/event/doma_wor.py
@@ -165,7 +165,7 @@ class DomaWOR(Event):
             field.Branch(space.end_address + 1), # skip nops
         )
 
-        if(self.args.flashes_remove_most):
+        if(self.args.flashes_remove_most or self.args.flashes_remove_worst):
             space = Reserve(0xb9952, 0xb9953, "doma wor sword appears flash 1", field.FlashScreen(field.Flash.NONE))
             space = Reserve(0xb9975, 0xb9976, "doma wor sword appears flashes", field.FlashScreen(field.Flash.NONE))
             space = Reserve(0xb99a9, 0xb99aa, "doma wor sword appears flash 3", field.FlashScreen(field.Flash.NONE))
@@ -262,7 +262,7 @@ class DomaWOR(Event):
         )
 
     def finish_dream_awaken_mod(self):
-        if(self.args.flashes_remove_most):
+        if(self.args.flashes_remove_most or self.args.flashes_remove_worst):
             space = Reserve(0xb9a47, 0xb9a48, "doma wor peak swordmanship flash", field.FlashScreen(field.Flash.NONE))
 
         src = [

--- a/event/duncan_house_wor.py
+++ b/event/duncan_house_wor.py
@@ -60,4 +60,4 @@ class DuncanHouseWOR(Event):
     def bum_rush_flash_mod(self):
         flash_addresses = [0xc0d12, 0xc0d5f, 0xc0d7f, 0xc0d9f, 0xc0df0, 0xc0e09, 0xc0e22, 0xc0e3b, 0xc0e65, 0xc0e74]
         for address in flash_addresses:
-            space = Reserve(address, address + 1, "duncan house wor bum rush flash", field.NOP())
+            space = Reserve(address, address + 1, "duncan house wor bum rush flash", field.FlashScreen(field.Flash.NONE))

--- a/event/floating_continent.py
+++ b/event/floating_continent.py
@@ -143,6 +143,12 @@ class FloatingContinent(Event):
         )
 
     def air_force_battle_mod(self):
+        if self.args.flashes_remove_most:
+            # Remove the scrolling background by modifying the background animation pointer table for offset 7 (falling through clouds).
+            # By setting the pointer to 0xB13D, it will keep the background from scrolling.
+            space = Reserve(0x2b0db, 0x2b0dc, "falling through clouds background animation")
+            space.write(0x3d, 0xb1)
+
         boss_pack_id = self.get_boss("Air Force")
         battle_background = 7 # sky, falling
 

--- a/event/floating_continent.py
+++ b/event/floating_continent.py
@@ -143,11 +143,12 @@ class FloatingContinent(Event):
         )
 
     def air_force_battle_mod(self):
-        if self.args.flashes_remove_most:
-            # Remove the scrolling background by modifying the background animation pointer table for offset 7 (falling through clouds).
-            # By setting the pointer to 0xB13D, it will keep the background from scrolling.
-            space = Reserve(0x2b0db, 0x2b0dc, "falling through clouds background animation")
-            space.write(0x3d, 0xb1)
+        if self.args.flashes_remove_most or self.args.flashes_remove_worst:
+            # Slow the scrolling background by modifying the ADC command.
+            space = Reserve(0x2b1b1, 0x2b1b3, "falling through clouds background movement")
+            space.write(
+                asm.ADC(0x0001, asm.IMM16) #default: 0x0006
+            )
 
         boss_pack_id = self.get_boss("Air Force")
         battle_background = 7 # sky, falling

--- a/event/magitek_factory.py
+++ b/event/magitek_factory.py
@@ -105,7 +105,7 @@ class MagitekFactory(Event):
 
         space = Reserve(0xc79a4, 0xc79cf, "magitek factory ifrit/shiva magicite", field.NOP())
         src = []
-        if self.args.flashes_remove_most:
+        if self.args.flashes_remove_most or self.args.flashes_remove_worst:
             src.append(field.FlashScreen(field.Flash.NONE))
         else:
             src.append(field.FlashScreen(field.Flash.WHITE))

--- a/event/magitek_factory.py
+++ b/event/magitek_factory.py
@@ -105,7 +105,9 @@ class MagitekFactory(Event):
 
         space = Reserve(0xc79a4, 0xc79cf, "magitek factory ifrit/shiva magicite", field.NOP())
         src = []
-        if not self.args.flashes_remove_most:
+        if self.args.flashes_remove_most:
+            src.append(field.FlashScreen(field.Flash.NONE))
+        else:
             src.append(field.FlashScreen(field.Flash.WHITE))
 
         src.append([

--- a/event/owzer_mansion.py
+++ b/event/owzer_mansion.py
@@ -42,7 +42,7 @@ class OwzerMansion(Event):
         self.log_reward(self.reward)
 
     def flash_mod(self):
-        space = Reserve(0xb4d10, 0xb4d11, "owzer mansion flash", field.NOP())
+        space = Reserve(0xb4d10, 0xb4d11, "owzer mansion flash", field.FlashScreen(field.Flash.NONE))
 
     def dialog_mod(self):
         space = Reserve(0xb4d0d, 0xb4d0f, "owzer mansion help that painting!!", field.NOP())

--- a/instruction/field/instructions.py
+++ b/instruction/field/instructions.py
@@ -406,6 +406,7 @@ def TintSpritePalette(tint, palette, invert = False):
     return TintSpritePalette(tint, palette * 0x10, palette * 0x10 + 0x0f, invert)
 
 class Flash(IntFlag):
+    NONE        = 0x00
     RED         = 0x20
     GREEN       = 0x40
     BLUE        = 0x80
@@ -413,7 +414,7 @@ class Flash(IntFlag):
     WHITE       = RED | GREEN | BLUE
 class FlashScreen(_Instruction):
     def __init__(self, color):
-        if not (color & Flash.RED) and not (color & Flash.GREEN) and not (color & Flash.BLUE):
+        if color != Flash.NONE and (not (color & Flash.RED) and not (color & Flash.GREEN) and not (color & Flash.BLUE)):
             raise ValueError(f"FlashScreen: invalid color {hex(color)}")
         super().__init__(0x55, color)
 


### PR DESCRIPTION
Moving Remove Flashes from Misc to Graphics, so that they don't affect the seed. Converted all event flash changes from NOPS to Flash None (55 00).

Slowing scrolling background on Falling through clouds and Baren Falls backgrounds.

Video test of scrolling background changes: 
https://www.youtube.com/watch?v=dw1HBKfxsw4 (note: this was an earlier change to Baren Falls with no palette swap changes)
https://www.youtube.com/watch?v=zDM8iaGub8w (this reflects the latest change to Baren Falls with the palette swap change)

Tested Misc->Graphics change by rolling seeds with 4 random characters but same `-s`. Ensured that the same random characters appeared regardless of having -frm, -frw, or neither of them.

-wmhc (World Minimap High Contrast):
![wmhc_wob](https://user-images.githubusercontent.com/96998881/197409343-4aa47672-40c8-483a-b8fb-64d3b904d08b.PNG)
![wmhc_wor](https://user-images.githubusercontent.com/96998881/197409345-30fa5cdf-c014-4ec9-8faa-5540979bff0c.PNG)

Changed boss flash removal to only flash the monster sprite:
Boss Death: https://www.youtube.com/watch?v=Tl8HXJEFmQc&ab_channel=SilverThorn
Kefka death: https://www.youtube.com/watch?v=fYXLS3BXDcY&ab_channel=SilverThorn
