### PR TITLE
Update coliseum flags to handle percentage random

### DIFF
--- a/args/coliseum.py
+++ b/args/coliseum.py
@@ -7,17 +7,11 @@ def parse(parser):
     coliseum = parser.add_argument_group("Coliseum")
 
     coliseum_opponents = coliseum.add_mutually_exclusive_group()
-    coliseum_opponents.add_argument("-cor", "--coliseum-opponents-random", default = None, type = int,
-                                    metavar = "PERCENT", choices = range(101),
-                                    help = "Coliseum opponents original with a given percent randomized")
     coliseum_opponents.add_argument("-cosr", "--coliseum-opponents-shuffle-random", default = None, type = int,
                                     metavar = "PERCENT", choices = range(101),
                                     help = "Coliseum opponents shuffled and then given percent randomized")
 
     coliseum_rewards = coliseum.add_mutually_exclusive_group()
-    coliseum_rewards.add_argument("-crr", "--coliseum-rewards-random", default = None, type = int,
-                                    metavar = "PERCENT", choices = range(101),
-                                    help = "Coliseum rewards original with a given percent randomized")
     coliseum_rewards.add_argument("-crsr", "--coliseum-rewards-shuffle-random", default = None, type = int,
                                     metavar = "PERCENT", choices = range(101),
                                     help = "Coliseum rewards shuffled and then a given percent randomized")

--- a/args/coliseum.py
+++ b/args/coliseum.py
@@ -7,16 +7,20 @@ def parse(parser):
     coliseum = parser.add_argument_group("Coliseum")
 
     coliseum_opponents = coliseum.add_mutually_exclusive_group()
-    coliseum_opponents.add_argument("-cos", "--coliseum-opponents-shuffle", action = "store_true",
-                                     help = "Coliseum opponents shuffled")
-    coliseum_opponents.add_argument("-cor", "--coliseum-opponents-random", action = "store_true",
-                                     help = "Coliseum opponents randomized")
+    coliseum_opponents.add_argument("-cor", "--coliseum-opponents-random", default = None, type = int,
+                                    metavar = "PERCENT", choices = range(101),
+                                    help = "Coliseum opponents original with a given percent randomized")
+    coliseum_opponents.add_argument("-cosr", "--coliseum-opponents-shuffle-random", default = None, type = int,
+                                    metavar = "PERCENT", choices = range(101),
+                                    help = "Coliseum opponents shuffled and then given percent randomized")
 
     coliseum_rewards = coliseum.add_mutually_exclusive_group()
-    coliseum_rewards.add_argument("-crs", "--coliseum-rewards-shuffle", action = "store_true",
-                                   help = "Coliseum rewards shuffled")
-    coliseum_rewards.add_argument("-crr", "--coliseum-rewards-random", action = "store_true",
-                                   help = "Coliseum rewards randomized")
+    coliseum_rewards.add_argument("-crr", "--coliseum-rewards-random", default = None, type = int,
+                                    metavar = "PERCENT", choices = range(101),
+                                    help = "Coliseum rewards original with a given percent randomized")
+    coliseum_rewards.add_argument("-crsr", "--coliseum-rewards-shuffle-random", default = None, type = int,
+                                    metavar = "PERCENT", choices = range(101),
+                                    help = "Coliseum rewards shuffled and then a given percent randomized")
 
     coliseum.add_argument("-crvr", "--coliseum-rewards-visible-random", default = None, type = int,
                           nargs = 2, metavar = ("MIN", "MAX"), choices = range(ITEM_COUNT),
@@ -34,16 +38,15 @@ def process(args):
 
 def flags(args):
     flags = ""
+    if args.coliseum_opponents_random:
+        flags += f" -cor {args.coliseum_opponents_random}"
+    elif args.coliseum_opponents_shuffle_random:
+        flags += f" -cor {args.coliseum_opponents_shuffle_random}"
 
-    if args.coliseum_opponents_shuffle:
-        flags += " -cos"
-    elif args.coliseum_opponents_random:
-        flags += " -cor"
-
-    if args.coliseum_rewards_shuffle:
-        flags += " -crs"
-    elif args.coliseum_rewards_random:
-        flags += " -crr"
+    if args.coliseum_rewards_random:
+        flags += f" -crr {args.coliseum_rewards_random}"
+    elif args.coliseum_rewards_shuffle_random:
+        flags += f" -crr {args.coliseum_rewards_shuffle_random}"
 
     if args.coliseum_rewards_visible_random:
         flags += f" -crvr {args.coliseum_rewards_visible_random_min} {args.coliseum_rewards_visible_random_max}"

--- a/args/coliseum.py
+++ b/args/coliseum.py
@@ -7,11 +7,17 @@ def parse(parser):
     coliseum = parser.add_argument_group("Coliseum")
 
     coliseum_opponents = coliseum.add_mutually_exclusive_group()
+    coliseum_opponents.add_argument("-cor", "--coliseum-opponents-random", default = None, type = int,
+                                    metavar = "PERCENT", choices = range(101),
+                                    help = "Coliseum opponents original with a given percent randomized")
     coliseum_opponents.add_argument("-cosr", "--coliseum-opponents-shuffle-random", default = None, type = int,
                                     metavar = "PERCENT", choices = range(101),
                                     help = "Coliseum opponents shuffled and then given percent randomized")
 
     coliseum_rewards = coliseum.add_mutually_exclusive_group()
+    coliseum_rewards.add_argument("-crr", "--coliseum-rewards-random", default = None, type = int,
+                                    metavar = "PERCENT", choices = range(101),
+                                    help = "Coliseum rewards original with a given percent randomized")
     coliseum_rewards.add_argument("-crsr", "--coliseum-rewards-shuffle-random", default = None, type = int,
                                     metavar = "PERCENT", choices = range(101),
                                     help = "Coliseum rewards shuffled and then a given percent randomized")

--- a/data/coliseum.py
+++ b/data/coliseum.py
@@ -30,9 +30,11 @@ class Coliseum():
         for match_index, match in enumerate(self.matches):
             match.opponent = opponents[match_index]
 
-    def randomize_opponents(self):
+    def randomize_opponents(self, random_opponent_percent = None):
+        import random
+
         for match in self.matches:
-            match.opponent = self.enemies.get_random()
+            match.opponent = self.enemies.get_random() if random_opponent_percent is not None and (random.random() < random_opponent_percent) else match.opponent
 
     def shuffle_rewards(self):
         rewards = []
@@ -44,9 +46,11 @@ class Coliseum():
         for match_index, match in enumerate(self.matches):
             match.reward = rewards[match_index]
 
-    def randomize_rewards(self):
+    def randomize_rewards(self, random_reward_percent = None):
+        import random
+
         for match in self.matches:
-            match.reward = self.items.get_random()
+            match.reward = self.items.get_random() if random_reward_percent is not None and (random.random() < random_reward_percent) else match.reward
 
     def remove_excluded_items(self):
         import random
@@ -76,15 +80,17 @@ class Coliseum():
             self.matches[match_index].reward_hidden = 1
 
     def mod(self):
-        if self.args.coliseum_opponents_shuffle:
+        if self.args.coliseum_opponents_random:
+            self.randomize_opponents(self.args.coliseum_opponents_random / 100.0)
+        elif self.args.coliseum_opponents_shuffle_random:
             self.shuffle_opponents()
-        elif self.args.coliseum_opponents_random:
-            self.randomize_opponents()
+            self.randomize_opponents(self.args.coliseum_opponents_shuffle_random / 100.0)
 
-        if self.args.coliseum_rewards_shuffle:
+        if self.args.coliseum_rewards_random:
+            self.randomize_rewards(self.args.coliseum_rewards_random / 100.0)
+        elif self.args.coliseum_rewards_shuffle_random:
             self.shuffle_rewards()
-        elif self.args.coliseum_rewards_random:
-            self.randomize_rewards()
+            self.randomize_rewards(self.args.coliseum_rewards_shuffle_random / 100.0)
 
         self.remove_excluded_items()
 


### PR DESCRIPTION
## Overview
Updated the coliseum random flags to be a bit more consistent with the other "random" flags - Which is, choosing a % an opponent/reward is random rather than randomizing all options

## Changes
* Added `coliseum-opponents-shuffle-random` (`-cosr`) and `coliseum-rewards-shuffle-random` (`-crsr`)  flags 
* Remove `-cos` , `-crs`, flags
    * `-cos` can now be written as `-cosr 0`
    * `-crs` can now be written as  `-crsr 0`