### PR TITLE
Feature/Bugfix: Adding --no-top-spells challenge flag. Removing Life spells in permadeath

### DIFF
--- a/args/challenges.py
+++ b/args/challenges.py
@@ -17,6 +17,8 @@ def parse(parser):
                             help = "Remove character/esper rewards from: Auction House, Collapsing House, Figaro Castle Throne, Gau's Father's House, Kohlingen Inn, Narshe Weapon Shop, Sealed Gate, South Figaro Basement")
     challenges.add_argument("-pd", "--permadeath", action = "store_true",
                             help = "Life spells cannot be learned. Fenix Downs unavailable (except from starting items). Buckets/inns/tents/events do not revive characters. Phoenix casts Life 3 on party instead of Life")
+    challenges.add_argument("-nts", "--no-top-spells", action = "store_true",
+                            help = "Remove top magic spells: all Tier 3, Ultima, Merton, Life 2, Quick, Pearl, and Flare")
 
 def process(args):
     pass
@@ -38,6 +40,8 @@ def flags(args):
         flags += " -nfce"
     if args.permadeath:
         flags += " -pd"
+    if args.no_top_spells:
+        flags += " -nts"
 
     return flags
 
@@ -50,6 +54,7 @@ def options(args):
         ("No Free Paladin Shields", args.no_free_paladin_shields),
         ("No Free Characters/Espers", args.no_free_characters_espers),
         ("Permadeath", args.permadeath),
+        ("No Top Spells", args.no_top_spells),
     ]
 
 def menu(args):

--- a/constants/spells.py
+++ b/constants/spells.py
@@ -55,3 +55,17 @@ id_spell = {
     53  : "Life 3",
 }
 spell_id = {v: k for k, v in id_spell.items()}
+
+top_spells = [
+    "Cure 3",
+    "Life 3",
+    "Life 2",
+    "Fire 3",
+    "Bolt 3",
+    "Ice 3",
+    "Quick",
+    "Merton",
+    "Ultima",
+    "Flare",
+    "Pearl",
+]

--- a/data/espers.py
+++ b/data/espers.py
@@ -159,6 +159,14 @@ class Espers():
             if esper.has_spell(life3_id):
                 esper.remove_spell(life3_id)
 
+    def remove_top_spells(self):
+        from constants.spells import top_spells
+        for top_spell in top_spells:
+            id = self.spells.get_id(top_spell)
+            for esper in self.espers:
+                if esper.has_spell(id):
+                    esper.remove_spell(id)
+
     def clear_spells(self):
         for esper in self.espers:
             esper.clear_spells()
@@ -280,6 +288,8 @@ class Espers():
 
         if self.args.no_ultima:
             self.remove_all_ultima()
+        if self.args.no_top_spells:
+            self.remove_top_spells()
 
         if self.args.esper_bonuses_shuffle:
             self.shuffle_bonuses()

--- a/data/natural_magic.py
+++ b/data/natural_magic.py
@@ -1,5 +1,6 @@
 from data.natural_spell import NaturalSpell
 from data.structures import DataArray
+from constants.spells import top_spells, spell_id
 
 from memory.space import Bank, Reserve, Allocate
 import instruction.asm as asm
@@ -153,6 +154,8 @@ class NaturalMagic:
             exclude.append(self.spells.get_id("Life"))
             exclude.append(self.spells.get_id("Life 2"))
             exclude.append(self.spells.get_id("Life 3"))
+        if self.args.no_top_spells:
+            exclude.append(top_spells)
 
         random_spells = self.spells.get_random(count = len(self.terra_spells), exclude = exclude)
         for index, spell in enumerate(random_spells):
@@ -166,6 +169,8 @@ class NaturalMagic:
             exclude.append(self.spells.get_id("Life"))
             exclude.append(self.spells.get_id("Life 2"))
             exclude.append(self.spells.get_id("Life 3"))
+        if self.args.no_top_spells:
+            exclude.append(top_spells)
 
         random_spells = self.spells.get_random(count = len(self.celes_spells), exclude = exclude)
         for index, spell in enumerate(random_spells):
@@ -183,6 +188,22 @@ class NaturalMagic:
     def remove_natural_ultima(self):
         self.terra_spells[-1].spell = 0
         self.terra_spells[-1].level = 0
+
+    def remove_natural_top_spells(self):
+        for top_spell in top_spells:
+            top_spell_id = spell_id[top_spell]
+
+            #linear search through Terra's spells
+            for terra_spell in self.terra_spells:
+                if terra_spell.spell == top_spell_id:
+                    terra_spell.spell = 0
+                    terra_spell.level = 0
+
+            #linear search through Celes' spells
+            for celes_spell in self.celes_spells:
+                if celes_spell.spell == top_spell_id:
+                    celes_spell.spell = 0
+                    celes_spell.level = 0
 
     def randomize_levels1(self):
         import random
@@ -221,6 +242,9 @@ class NaturalMagic:
                 self.randomize_levels2()
             if self.args.random_natural_spells2:
                 self.randomize_spells2()
+
+        if self.args.no_top_spells:
+            self.remove_natural_top_spells()
 
     def log(self):
         from log import section, format_option

--- a/objectives/results/forget_spells.py
+++ b/objectives/results/forget_spells.py
@@ -2,11 +2,20 @@ from objectives.results._objective_result import *
 import args
 
 def _random_spell_table():
-    from constants.spells import spell_id
+    from constants.spells import spell_id, top_spells
 
     spell_table = list(range(len(spell_id)))
     if args.no_ultima:
         spell_table.remove(spell_id["Ultima"])
+    if args.permadeath:
+        spell_table.remove(spell_id["Life"])
+        spell_table.remove(spell_id["Life 2"])
+        spell_table.remove(spell_id["Life 3"])
+    if args.no_top_spells:
+        for top_spell in top_spells:
+            id = spell_id[top_spell]
+            if id in spell_table:
+                spell_table.remove(spell_id[top_spell])
     random.shuffle(spell_table)
 
     space = Write(Bank.F0, spell_table, "forget spells random spell table")

--- a/objectives/results/learn_spells.py
+++ b/objectives/results/learn_spells.py
@@ -2,11 +2,21 @@ from objectives.results._objective_result import *
 import args
 
 def _random_spell_table():
-    from constants.spells import spell_id
+    from constants.spells import spell_id, top_spells
 
     spell_table = list(range(len(spell_id)))
     if args.no_ultima:
         spell_table.remove(spell_id["Ultima"])
+    if args.permadeath:
+        spell_table.remove(spell_id["Life"])
+        spell_table.remove(spell_id["Life 2"])
+        spell_table.remove(spell_id["Life 3"])
+    if args.no_top_spells:
+        for top_spell in top_spells:
+            id = spell_id[top_spell]
+            if id in spell_table:
+                spell_table.remove(spell_id[top_spell])
+
     random.shuffle(spell_table)
 
     space = Write(Bank.F0, spell_table, "learn spells random spell table")


### PR DESCRIPTION

Adds a --no-top-spells (-ntm) flag to remove all Tier 3, Ultima, Merton, Life 2, Quick, Pearl, and Flare spells.
Fixes bug with Learn Spells reward in which Life spells can appear during permadeath seeds.

**Test notes:**
Generated seed with -ob 31.54.54.0.0, -ntm, and --permadeath
--- confirmed in game that none of the top spells nor Life spells were learned
--- confirmed in spoiler log that no Espers had top spells nor Life spells

Generated seed with -rns1, rns2, and -ntm
--- confirmed in spoiler log that none of the top spells were naturally learned and no Espers had top spells

Generated seed with -ntm but without -rns1, -rns2
--- confirmed in spoiler log that none of the top spells were naturally learned and no Espers had top spells

