### PR TITLE
Bugfix: if permadeath, replace life with cure 2 in rhobite rage

### DIFF
--- a/data/rages.py
+++ b/data/rages.py
@@ -5,6 +5,7 @@ class Rages():
     RAGE_COUNT = 256 # 255 available
     DOOM_DRGN_RAGE_ID = 37
     NIGHTSHADE_RAGE_ID = 51
+    RHOBITE_RAGE_ID = 118
     PUGS_RAGE_ID = 255 # does not appear in rage list, cannot be used
 
     INITIAL_RAGES_START = 0x47aa0
@@ -66,6 +67,11 @@ class Rages():
             asm.BRA("EMPTY_COMMAND_SLOT"),
         )
 
+    def no_life(self):
+        from data.spell_names import name_id
+        # change Robite to cure 2 from life
+        self.rages[self.RHOBITE_RAGE_ID].attack2 = name_id["Cure 2"]
+
     def no_charm(self):
         # change nightshade charm to special attack (poison pod)
         self.rages[self.NIGHTSHADE_RAGE_ID].attack2 = 239
@@ -79,6 +85,9 @@ class Rages():
 
         if self.args.rages_no_charm:
             self.no_charm()
+
+        if self.args.permadeath:
+            self.no_life()
 
     def write(self):
         if self.args.spoiler_log:


### PR DESCRIPTION
Replacing Life with Cure 2 in Rhobite rage if permadeath. Tested by generating a permadeath seed and checking rages in ff3usME:

![image](https://user-images.githubusercontent.com/96998881/156937691-642c36fd-5bf1-4704-8fc3-aca3bea5755b.png)
