### PR TITLE
Bugfix: Fixing crashes due to a lot of Add ... Level Objectives

### DIFF
--- a/memory/label.py
+++ b/memory/label.py
@@ -23,6 +23,8 @@ class LabelPointer:
             return abs(value - self.address)
         elif self.mode == self.BRANCH_RELATIVE:
             value -= self.address
+            if value > 127 or value < -128:
+                raise ValueError(f"Error on Branch to label {self.label.name}. Branch distance: {value-1}")
             if value > 0:
                 return value - 1
             elif value < 0:


### PR DESCRIPTION
This seed exposed an issue with add_enemy_levels in which the resulting branch instructions can end up exceeding 127 bytes and therefore branch into other F0 code, ultimate crashing the game.

This was exposed with this flag set. Going to the Whelk boss, for example, would crash the game at the start of that battle.
```
-open -oa 2.3.3.2.3.3.4.21.21.6.8.8 -ob 30.8.8.1.1.11.8 -oc 24.16.16.0.0 -od 23.16.16.0.0 -oe 41.0.0 -of 21.23.23.1.1.11.4 -og 21.23.23.1.1.11.15 -oh 21.23.23.1.1.11.20 -oi 21.23.23.1.1.11.25 -oj 21.23.23.1.1.11.27 -ok 21.23.23.1.1.11.46 -ol 21.23.23.1.1.11.49 -om 21.23.23.1.1.11.54 -on 35.1.1.11.3 -oo 35.1.1.11.5 -op 35.1.1.11.32 -oq 58.1.1.11.44 -or 58.1.1.11.51 -os 39.1.1.11.57 -sc1 celes -sc2 edgar -sc3 setzer -sal -eu -csrp 100 120 -fst -brl -slr 3 3 -lmprv 16 80 -lel -srr 28 28 -rnl -rnc -sdr 4 4 -das -dda -dns -del -sch -com 99999999999999999999999999 -rec1 28 -rec2 6 -rec3 29 -rec4 27 -xpm 3 -mpm 3 -gpm 3 -nxppd -lsced 2.5 -hmc 3 -xgced 2.5 -msl 80 -bbs -bnu -res -fer 0 -escr 100 -dgne -wnz -mmnu -cmd -ess -ebr 50 -emprv 16 99 -nm1 random -rns1 -nm2 celes -nmmi -gp 2000 -smc 3 -sws 6 -sto 2 -iebr 9 -ieror 100 -csb 18 18 -mca -stra -saw -sisr 25 -sprp 75 125 -sdm 5 -npi -snbr -snes -snsb -snee -snil -ccsr 10 -cpal 0.144.4.3.92.5.6 -cspr 123.156.2.32.4.5.6.7.104.9.92.68.12.142.10.10.18.10.10.10 -cspp 1.1.2.0.0.0.0.3.4.2.5.3.3.5.2.0.6.4.6.1 -crm -cnee -anca -adeh -nmc -nfps -nu -nfce -fs -fe -fvd -fj -fbs -fedc -as -ond -rr -scan -etn
```

This change simply inverts the branches such that that will not be an issue -- it'll just immediately return.

An update to label.py was made to catch any attempts to branch <-128 or >127 bytes. During testing, this proved to catch the original bug.