### PR TITLE
Bugfix: Can't learn Bum Rush if recruited >= 42

### DIFF
--- a/data/blitzes.py
+++ b/data/blitzes.py
@@ -15,6 +15,10 @@ class Blitzes:
 
         self.levels = DataArray(self.rom, self.LEVELS_START, self.LEVELS_END, Blitz.LEVEL_SIZE)
 
+        import data.event_bit as event_bit
+        self.can_learn_byte = 0x1e80 + event_bit.byte(event_bit.CAN_LEARN_BUM_RUSH)
+        self.can_learn_bit = 2 ** event_bit.bit(event_bit.CAN_LEARN_BUM_RUSH)
+
         self.blitzes = []
         for blitz_index in range(len(self.levels)):
             blitz = Blitz(blitz_index, self.levels[blitz_index])
@@ -50,28 +54,51 @@ class Blitzes:
         learn_blitzes = 0x0a201
         character_recruited = c0.character_recruited + START_ADDRESS_SNES
 
-        space = Allocate(Bank.C0, 24, "blitz event check", asm.NOP())
-        space.write(
+        src = [
             asm.PHA(),
             asm.JSL(character_recruited),
             asm.CMP(0x00, asm.IMM8),        # compare result with 0
             asm.BEQ("RETURN"),              # branch if character not recruited
-        )
+        ]
         if not self.args.blitzes_everyone_learns:
-            space.write(
+            src += [
                 asm.PLA(),
                 asm.PHA(),
                 asm.JSL(self.is_learner_function),
                 asm.CMP(0x00, asm.IMM8),    # compare result with 0
                 asm.BEQ("RETURN"),          # branch if character not learner
-            )
-        space.write(
+            ]
+        src += [
             asm.JSR(learn_blitzes, asm.ABS),
+
+            # when a new blitz is learned, check if 7 total now learned and if so set event bit
+            asm.PHX(),
+            asm.PHP(),
+            asm.LDA(0x1d28, asm.ABS),           # a = known blitzes
+            asm.XY8(),
+            # Sets X to number of bits set in A. So, x = number known blitzes
+            # Logic Copied from C2/520e
+            asm.LDX(0x00, asm.IMM8),
+            "LOOP_START",
+            asm.LSR(),
+            asm.BCC("BIT_NOT_SET"),
+            asm.INX(),
+            "BIT_NOT_SET",
+            asm.BNE("LOOP_START"),              # repeat loop to count all bits set in A
+            asm.CPX(0x07, asm.IMM8),            # 7 blitzes known? (total learnable except bum rush)
+            asm.BLT("DONE_7_CHECK"),        # branch if < 7 blitzes known
+            asm.LDA(self.can_learn_bit, asm.IMM8),   # load can learn bum rush bit
+            asm.TSB(self.can_learn_byte, asm.ABS),   # set can learn bum rush event bit
+
+            "DONE_7_CHECK",
+            asm.PLP(),
+            asm.PLX(),
 
             "RETURN",
             asm.PLA(),
             asm.RTS(),
-        )
+        ]
+        space = Write(Bank.C0, src, "blitz event check")
         check_blitzes = space.start_address
 
         space = Reserve(0x0a18e, 0x0a194, "event check sabin learn blitzes", asm.NOP())
@@ -122,11 +149,6 @@ class Blitzes:
 
     def blitzes_learned_event_bit(self):
         # when a new blitz is learned, check if 7 total now learned and if so set event bit
-
-        import data.event_bit as event_bit
-        can_learn_byte = 0x1e80 + event_bit.byte(event_bit.CAN_LEARN_BUM_RUSH)
-        can_learn_bit = 2 ** event_bit.bit(event_bit.CAN_LEARN_BUM_RUSH)
-
         src = [
             asm.PHX(),
             asm.PHP(),
@@ -135,8 +157,8 @@ class Blitzes:
             asm.JSR(0x520e, asm.ABS),           # x = number known blitzes
             asm.CPX(0x07, asm.IMM8),            # 7 blitzes known? (total learnable except bum rush)
             asm.BLT("RETURN"),                  # branch if < 7 blitzes known
-            asm.LDA(can_learn_bit, asm.IMM8),   # load can learn bum rush bit
-            asm.TSB(can_learn_byte, asm.ABS),   # set can learn bum rush event bit
+            asm.LDA(self.can_learn_bit, asm.IMM8),   # load can learn bum rush bit
+            asm.TSB(self.can_learn_byte, asm.ABS),   # set can learn bum rush event bit
 
             "RETURN",
             asm.PLP(),


### PR DESCRIPTION
Fixing bug that prevented learning Bum Rush if the Blitzer was recruited at level >= 42

Ref: https://discord.com/channels/666661907628949504/666811452350398493/964611903068454993

Test flags: 
```
-cg -sl -oa 45.99.99.0.0 -ob 46.99.99.0.0 -oc 47.99.99.0.0 -od 48.99.99.0.0 -sc1 terra -sal -eu -csrp 200 200 -fst -brl -slr 1 5 -lmprp 75 125 -lel -srr 3 15 -rnl -rnc -sdr 1 1 -das -dda -dns -com 27101010101010101010101027 -rec1 28 -rec2 23 -xpm 255 -mpm 255 -gpm 255 -nxppd -lsced 2 -hmced 2 -xgced 2 -ase 2 -msl 40 -sed -bbs -be -bnu -res -fer 0 -escr 100 -dgne -wnz -mmnu -cmd -esr 1 5 -ebr 68 -emprp 75 125 -nm1 random -rnl1 -rns1 -nm2 random -rnl2 -rns2 -nmmi -gp 999999 -smc 3 -sws 10 -sfd 10 -ieor 33 -ieror 33 -csb 1 32 -mca -stra -saw -sisr 20 -sprp 75 125 -sdm 4 -npi -ccsr 20 -cms -cor -crr -crvr 255 255 -ari -anca -adeh -nfps -nu -fs -fe -fvd -fr -fj -fbs -fedc -as -ond -rr
```

Video of fix:
https://www.youtube.com/watch?v=nAJKAZqG0VY


Also confirmed that getting to 42 through level ups still sets the CAN_LEARN_BUM_RUSH flag.
Also confirmed that CAN_LEARN_BUM_RUSH flag is not set if you recruit the Blitzer at level <42


