### PR TITLE
Feature: Magic MP Randomization

### DIFF
--- a/args/arguments.py
+++ b/args/arguments.py
@@ -6,7 +6,7 @@ class Arguments:
             "objectives",
             "starting_party", "characters", "swdtechs", "blitzes", "lores", "rages", "dances", "steal", "commands",  
             "xpmpgp", "scaling", "bosses", "encounters", "boss_ai",
-            "espers", "natural_magic",
+            "espers", "natural_magic", "misc_magic",
             "starting_gold_items", "items", "shops", "chests",
             "graphics",
             "coliseum", "auction_house", "challenges", "bug_fixes", "misc",

--- a/args/challenges.py
+++ b/args/challenges.py
@@ -9,8 +9,11 @@ def parse(parser):
                             help = "Exp. Eggs will not appear in coliseum/auction/shops/chests/events")
     challenges.add_argument("-nil", "--no-illuminas", action = "store_true",
                             help = "Illuminas will not appear in coliseum/auction/shops/chests/events")
-    challenges.add_argument("-nu", "--no-ultima", action = "store_true",
+    ultima = challenges.add_mutually_exclusive_group()
+    ultima.add_argument("-nu", "--no-ultima", action = "store_true",
                             help = "Ultima cannot be learned from espers/items/natural magic")
+    ultima.add_argument("-u255", "--ultima-255-mp", action = "store_true",
+                            help = "Ultima costs 255 MP")
     challenges.add_argument("-nfps", "--no-free-paladin-shields", action = "store_true",
                             help = "Paladin/Cursed Shields will not appear in coliseum/auction/shops/chests/events (Narshe WOR exclusive)")
     challenges.add_argument("-nfce", "--no-free-characters-espers", action = "store_true",
@@ -32,6 +35,9 @@ def flags(args):
         flags += " -nil"
     if args.no_ultima:
         flags += " -nu"
+    elif args.ultima_255_mp:
+        flags += " -u255"
+
     if args.no_free_paladin_shields:
         flags += " -nfps"
     if args.no_free_characters_espers:
@@ -42,11 +48,17 @@ def flags(args):
     return flags
 
 def options(args):
+    ultima = "Original"
+    if args.no_ultima:
+        ultima = "No"
+    elif args.ultima_255_mp:
+        ultima = "255 MP"
+
     return [
         ("No Moogle Charms", args.no_moogle_charms),
         ("No Exp Eggs", args.no_exp_eggs),
         ("No Illuminas", args.no_illuminas),
-        ("No Ultima", args.no_ultima),
+        ("Ultima", ultima),
         ("No Free Paladin Shields", args.no_free_paladin_shields),
         ("No Free Characters/Espers", args.no_free_characters_espers),
         ("Permadeath", args.permadeath),

--- a/args/challenges.py
+++ b/args/challenges.py
@@ -12,8 +12,8 @@ def parse(parser):
     ultima = challenges.add_mutually_exclusive_group()
     ultima.add_argument("-nu", "--no-ultima", action = "store_true",
                             help = "Ultima cannot be learned from espers/items/natural magic")
-    ultima.add_argument("-u255", "--ultima-255-mp", action = "store_true",
-                            help = "Ultima costs 255 MP")
+    ultima.add_argument("-u254", "--ultima-254-mp", action = "store_true",
+                            help = "Ultima costs 254 MP")
     challenges.add_argument("-nfps", "--no-free-paladin-shields", action = "store_true",
                             help = "Paladin/Cursed Shields will not appear in coliseum/auction/shops/chests/events (Narshe WOR exclusive)")
     challenges.add_argument("-nfce", "--no-free-characters-espers", action = "store_true",
@@ -35,8 +35,8 @@ def flags(args):
         flags += " -nil"
     if args.no_ultima:
         flags += " -nu"
-    elif args.ultima_255_mp:
-        flags += " -u255"
+    elif args.ultima_254_mp:
+        flags += " -u254"
 
     if args.no_free_paladin_shields:
         flags += " -nfps"
@@ -51,8 +51,8 @@ def options(args):
     ultima = "Original"
     if args.no_ultima:
         ultima = "No"
-    elif args.ultima_255_mp:
-        ultima = "255 MP"
+    elif args.ultima_254_mp:
+        ultima = "254 MP"
 
     return [
         ("No Moogle Charms", args.no_moogle_charms),

--- a/args/espers.py
+++ b/args/espers.py
@@ -30,7 +30,7 @@ def parse(parser):
     esper_mp.add_argument("-emps", "--esper-mp-shuffle", action = "store_true",
                           help = "Esper MP costs shuffled")
     esper_mp.add_argument("-emprv", "--esper-mp-random-value", default = None, type = int,
-                          nargs = 2, metavar = ("MIN", "MAX"), choices = range(129),
+                          nargs = 2, metavar = ("MIN", "MAX"), choices = range(256),
                           help = "Each esper's MP cost set to random value within given range")
     esper_mp.add_argument("-emprp", "--esper-mp-random-percent", default = None, type = int,
                           nargs = 2, metavar = ("MIN", "MAX"), choices = range(201),

--- a/args/espers.py
+++ b/args/espers.py
@@ -30,7 +30,7 @@ def parse(parser):
     esper_mp.add_argument("-emps", "--esper-mp-shuffle", action = "store_true",
                           help = "Esper MP costs shuffled")
     esper_mp.add_argument("-emprv", "--esper-mp-random-value", default = None, type = int,
-                          nargs = 2, metavar = ("MIN", "MAX"), choices = range(256),
+                          nargs = 2, metavar = ("MIN", "MAX"), choices = range(255),
                           help = "Each esper's MP cost set to random value within given range")
     esper_mp.add_argument("-emprp", "--esper-mp-random-percent", default = None, type = int,
                           nargs = 2, metavar = ("MIN", "MAX"), choices = range(201),

--- a/args/log.py
+++ b/args/log.py
@@ -19,7 +19,7 @@ def log():
     args.group_modules["objectives"].log(args)
     _log_tab("Party", ["starting_party", "swdtechs", "blitzes", "lores", "rages", "dances", "steal"], ["characters", "commands"])
     _log_tab("Battle", ["xpmpgp", "bosses", "boss_ai"], ["scaling", "encounters"])
-    _log_tab("Magic", ["espers"], ["natural_magic"])
+    _log_tab("Magic", ["espers", "misc_magic"], ["natural_magic"])
     _log_tab("Items", ["starting_gold_items", "items"], ["shops", "chests"])
     args.group_modules["graphics"].log(args)
     _log_tab("Other", ["coliseum", "auction_house", "misc"], ["challenges", "bug_fixes"])

--- a/args/lores.py
+++ b/args/lores.py
@@ -14,7 +14,7 @@ def parse(parser):
     lores_mp.add_argument("-lmps", "--lores-mp-shuffle", action = "store_true",
                           help = "Lore MP costs shuffled")
     lores_mp.add_argument("-lmprv", "--lores-mp-random-value", default = None, type = int,
-                          nargs = 2, metavar = ("MIN", "MAX"), choices = range(100),
+                          nargs = 2, metavar = ("MIN", "MAX"), choices = range(256),
                           help = "Lore MP costs randomized")
     lores_mp.add_argument("-lmprp", "--lores-mp-random-percent", default = None, type = int,
                           nargs = 2, metavar = ("MIN", "MAX"), choices = range(201),

--- a/args/lores.py
+++ b/args/lores.py
@@ -14,7 +14,7 @@ def parse(parser):
     lores_mp.add_argument("-lmps", "--lores-mp-shuffle", action = "store_true",
                           help = "Lore MP costs shuffled")
     lores_mp.add_argument("-lmprv", "--lores-mp-random-value", default = None, type = int,
-                          nargs = 2, metavar = ("MIN", "MAX"), choices = range(256),
+                          nargs = 2, metavar = ("MIN", "MAX"), choices = range(255),
                           help = "Lore MP costs randomized")
     lores_mp.add_argument("-lmprp", "--lores-mp-random-percent", default = None, type = int,
                           nargs = 2, metavar = ("MIN", "MAX"), choices = range(201),

--- a/args/misc_magic.py
+++ b/args/misc_magic.py
@@ -1,0 +1,68 @@
+def name():
+    return "Misc. Magic"
+
+def parse(parser):
+    magic = parser.add_argument_group("Misc. Magic")
+
+    magic_mp = magic.add_mutually_exclusive_group()
+    magic_mp.add_argument("-mmps", "--magic-mp-shuffle", action = "store_true",
+                          help = "Magic spells' MP costs shuffled")
+    magic_mp.add_argument("-mmprv", "--magic-mp-random-value", default = None, type = int,
+                          nargs = 2, metavar = ("MIN", "MAX"), choices = range(256),
+                          help = "Magic spells' MP costs randomized")
+    magic_mp.add_argument("-mmprp", "--magic-mp-random-percent", default = None, type = int,
+                          nargs = 2, metavar = ("MIN", "MAX"), choices = range(201),
+                          help = "Each Magic spell's MP cost set to random percent of original within given range")
+
+def process(args):
+    args._process_min_max("magic_mp_random_value")
+    args._process_min_max("magic_mp_random_percent")
+
+def flags(args):
+    flags = ""
+
+    if args.magic_mp_shuffle:
+        flags += " -mmps"
+    elif args.magic_mp_random_value:
+        flags += f" -mmprv {args.magic_mp_random_value_min} {args.magic_mp_random_value_max}"
+    elif args.magic_mp_random_percent:
+        flags += f" -mmprp {args.magic_mp_random_percent_min} {args.magic_mp_random_percent_max}"
+
+    return flags
+
+def options(args):
+
+    mp = "Original"
+    if args.magic_mp_shuffle:
+        mp = "Shuffle"
+    elif args.magic_mp_random_value:
+        mp = f"Random Value {args.magic_mp_random_value_min}-{args.magic_mp_random_value_max}"
+    elif args.magic_mp_random_percent:
+        mp = f"Random Percent {args.magic_mp_random_percent_min}-{args.magic_mp_random_percent_max}%"
+
+    return [
+        ("MP", mp),
+    ]
+
+def menu(args):
+    entries = options(args)
+    for index, entry in enumerate(entries):
+        key, value = entry
+        try:
+            if key == "MP":
+                value = value.replace("Random Value ", "")
+                value = value.replace("Random Percent ", "")
+            entries[index] = (key, value)
+        except:
+            pass
+    return (name(), entries)
+
+def log(args):
+    from log import format_option
+    log = [name()]
+
+    entries = options(args)
+    for entry in entries:
+        log.append(format_option(*entry))
+
+    return log

--- a/args/misc_magic.py
+++ b/args/misc_magic.py
@@ -8,7 +8,7 @@ def parse(parser):
     magic_mp.add_argument("-mmps", "--magic-mp-shuffle", action = "store_true",
                           help = "Magic spells' MP costs shuffled")
     magic_mp.add_argument("-mmprv", "--magic-mp-random-value", default = None, type = int,
-                          nargs = 2, metavar = ("MIN", "MAX"), choices = range(256),
+                          nargs = 2, metavar = ("MIN", "MAX"), choices = range(255),
                           help = "Magic spells' MP costs randomized")
     magic_mp.add_argument("-mmprp", "--magic-mp-random-percent", default = None, type = int,
                           nargs = 2, metavar = ("MIN", "MAX"), choices = range(201),

--- a/data/espers.py
+++ b/data/espers.py
@@ -202,7 +202,7 @@ class Espers():
             mp_percent = random.randint(self.args.esper_mp_random_percent_min,
                                         self.args.esper_mp_random_percent_max) / 100.0
             value = int(esper.mp * mp_percent)
-            esper.mp = max(min(value, 255), 1)
+            esper.mp = max(min(value, 254), 1)
 
     def equipable_random(self):
         from data.characters import Characters

--- a/data/lores.py
+++ b/data/lores.py
@@ -158,7 +158,7 @@ class Lores:
             mp_percent = random.randint(self.args.lores_mp_random_percent_min,
                                         self.args.lores_mp_random_percent_max) / 100.0
             value = int(lore.mp * mp_percent)
-            lore.mp = max(min(value, 255), 0)
+            lore.mp = max(min(value, 254), 0)
 
     def mod(self):
         self.write_learners_table()

--- a/data/spells.py
+++ b/data/spells.py
@@ -53,17 +53,70 @@ class Spells:
         scan_id = name_id["Scan"]
         self.spells[scan_id].mp = 0
 
+    def ultima_255_mp(self):
+        ultima_id = name_id["Ultima"]
+        self.spells[ultima_id].mp = 255
+
+    def shuffle_mp(self):
+        mp = []
+        for spell in self.spells:
+            mp.append(spell.mp)
+
+        import random
+        random.shuffle(mp)
+        for spell in self.spells:
+            spell.mp = mp.pop()
+
+    def random_mp_value(self):
+        import random
+        for spell in self.spells:
+            spell.mp = random.randint(self.args.magic_mp_random_value_min, self.args.magic_mp_random_value_max)
+
+    def random_mp_percent(self):
+        import random
+        for spell in self.spells:
+            mp_percent = random.randint(self.args.magic_mp_random_percent_min,
+                                        self.args.magic_mp_random_percent_max) / 100.0
+            value = int(spell.mp * mp_percent)
+            spell.mp = max(min(value, 255), 0)
+
     def mod(self):
+        if self.args.magic_mp_shuffle:
+            self.shuffle_mp()
+        elif self.args.magic_mp_random_value:
+            self.random_mp_value()
+        elif self.args.magic_mp_random_percent:
+            self.random_mp_percent()
+
+        # Apply No MP Scan after any MP shuffle/rando
         if self.args.scan_all:
             self.no_mp_scan()
 
+        # Apply Ultima 255 MP after any MP shuffle/rando
+        if self.args.ultima_255_mp:
+            self.ultima_255_mp()
+
     def write(self):
+        if self.args.spoiler_log:
+            self.log()
+            
         for spell_index, spell in enumerate(self.spells):
             self.name_data[spell_index] = spell.name_data()
             self.ability_data[spell_index] = spell.ability_data()
 
         self.name_data.write()
         self.ability_data.write()
+
+    def log(self):
+        from log import section
+        
+        lcolumn = []
+        for spell in self.spells:
+            spell_name = spell.get_name()
+
+            lcolumn.append(f"{spell_name:<{self.NAME_SIZE}} {spell.mp:>3} MP")
+        
+        section("Spells", lcolumn, [])
 
     def print(self):
         for spell in self.spells:

--- a/data/spells.py
+++ b/data/spells.py
@@ -53,9 +53,9 @@ class Spells:
         scan_id = name_id["Scan"]
         self.spells[scan_id].mp = 0
 
-    def ultima_255_mp(self):
+    def ultima_254_mp(self):
         ultima_id = name_id["Ultima"]
-        self.spells[ultima_id].mp = 255
+        self.spells[ultima_id].mp = 254
 
     def shuffle_mp(self):
         mp = []
@@ -92,9 +92,9 @@ class Spells:
         if self.args.scan_all:
             self.no_mp_scan()
 
-        # Apply Ultima 255 MP after any MP shuffle/rando
-        if self.args.ultima_255_mp:
-            self.ultima_255_mp()
+        # Apply Ultima 254 MP after any MP shuffle/rando
+        if self.args.ultima_254_mp:
+            self.ultima_254_mp()
 
     def write(self):
         if self.args.spoiler_log:

--- a/data/spells.py
+++ b/data/spells.py
@@ -78,7 +78,7 @@ class Spells:
             mp_percent = random.randint(self.args.magic_mp_random_percent_min,
                                         self.args.magic_mp_random_percent_max) / 100.0
             value = int(spell.mp * mp_percent)
-            spell.mp = max(min(value, 255), 0)
+            spell.mp = max(min(value, 254), 0)
 
     def mod(self):
         if self.args.magic_mp_shuffle:

--- a/menus/magic.py
+++ b/menus/magic.py
@@ -16,14 +16,14 @@ class MagicMenu:
             # displaced vanilla logic, from C3/51E9 - 51ED 
             asm.LDA(0xF8, asm.DIR),             # Tens digit
             asm.STA(STRING_DRAW_ADDR, asm.ABS), # Add to string
-            asm.RTS()
+            asm.RTL()
         ]
-        space = Write(Bank.C3, src, "Create MP Cost string")
-        create_string = space.start_address
+        space = Write(Bank.F0, src, "Create MP Cost string")
+        create_string = space.start_address_snes
 
         space = Reserve(0x351e9, 0x351ed, "Call create_string", asm.NOP())
         space.write(
-            asm.JSR(create_string, asm.ABS),
+            asm.JSL(create_string),
         )
 
         # Move where MP gets written 1 space to the left, 

--- a/menus/magic.py
+++ b/menus/magic.py
@@ -1,0 +1,42 @@
+from memory.space import Write, Bank, Reserve
+import instruction.asm as asm
+import args
+
+class MagicMenu:
+    def __init__(self):
+        self.mod()
+
+    def draw_three_digits(self):
+        # Enable drawing of 3 digits
+        # Create string function
+        STRING_DRAW_ADDR = 0x2180 # Where to write strings to be written
+        src = [
+            asm.LDA(0xF7, asm.DIR),             # Hundreds digit
+            asm.STA(STRING_DRAW_ADDR, asm.ABS), # Add to string
+            # displaced vanilla logic, from C3/51E9 - 51ED 
+            asm.LDA(0xF8, asm.DIR),             # Tens digit
+            asm.STA(STRING_DRAW_ADDR, asm.ABS), # Add to string
+            asm.RTS()
+        ]
+        space = Write(Bank.C3, src, "Create MP Cost string")
+        create_string = space.start_address
+
+        space = Reserve(0x351e9, 0x351ed, "Call create_string", asm.NOP())
+        space.write(
+            asm.JSR(create_string, asm.ABS),
+        )
+
+        # Move where MP gets written 1 space to the left, 
+        # to avoid having the number show up at the top of the "Espers" menu
+        space = Reserve(0x351cd, 0x351cd, "MP String location")
+        space.write(0xbd) #original: 0xbf (each text space is a value of 2)
+
+    def fix_in_battle_mp_tens_digit(self):
+        # Fix Vanilla in-battle MP listing in which the ten's digit is blanked
+        # if it is 0 but the hundreds digit is not
+        space = Reserve(0x1057b, 0x1057b, "MP Hundreds non-zero BNE offset")
+        space.write(0x14) # original: 0x08; 0x14 causes it to jump to RTS if the hundreds place is non-zero
+
+    def mod(self):
+        self.draw_three_digits()
+        self.fix_in_battle_mp_tens_digit()

--- a/menus/menus.py
+++ b/menus/menus.py
@@ -6,6 +6,7 @@ import menus.status as status
 import menus.final_lineup as final_lineup
 import menus.coliseum as coliseum
 import menus.sell as sell
+import menus.magic as magic
 
 class Menus:
     def __init__(self, characters, dances):
@@ -20,6 +21,7 @@ class Menus:
         self.final_lineup_menu = final_lineup.FinalLineupMenu(self.characters)
         self.coliseum_menu = coliseum.ColiseumMenu()
         self.sell_menu = sell.SellMenu()
+        self.magic_menu = magic.MagicMenu()
 
         self.scrollbar_bugfix()
 


### PR DESCRIPTION
- Adding Ultima 254 MP flag
- Adding Franklin's Magic MP Randomization
- Fixing display bugs with 3 digit MP
- Letting Lore & Esper MP randomization go to 254 MP

### Testing notes

- Confirmed spoiler log MP costs (Esper, Lore, Spells) matched those in game, and matched the desired shuffle/rando selection.
- Confirmed that 254 MP spells can be cast (and aren't grayed out like 255 MP ones)
- Ran a beta seed with these flags: `-oa 45.99.99.0.0 -ob 48.99.99.0.0 -oc 46.99.99.0.0 -od 47.99.99.0.0 -sc1 terra -sc2 locke -sc3 sabin -com 10129898982998989898989898  -hmced 0.5 -as -frm -mca -smc 3 -gp 100000 -ase 0.5 -be -bbs -brl -sl -nm1 terra -mmprv 253 254 -emprv 253 254 -lmprv 253 254 -sl -oe 31.54.54.0.0 -u254 -xpm 99 -stl 42 -slr 24 24 -scan -stesp 21 21 -cg`
   - Video: https://youtu.be/O663kIWxNvI