### PR TITLE
Feature: Set Starting level

### DIFF
--- a/args/characters.py
+++ b/args/characters.py
@@ -6,6 +6,8 @@ def parse(parser):
 
     characters.add_argument("-sal", "--start-average-level", action = "store_true",
                             help = "Recruited characters start at the average character level")
+    characters.add_argument("-stl", "--start-level", default = 3, type = int, choices = range(3, 100), metavar = "COUNT",
+                            help = "Start game at level %(metavar)s.")
     characters.add_argument("-sn", "--start-naked", action = "store_true",
                             help = "Recruited characters start with no equipment")
     characters.add_argument("-eu", "--equipable-umaro", action = "store_true",
@@ -22,6 +24,8 @@ def flags(args):
 
     if args.start_average_level:
         flags += " -sal"
+    if args.start_level != 3:
+        flags += f" -stl {args.start_level}"
     if args.start_naked:
         flags += " -sn"
     if args.equipable_umaro:
@@ -36,6 +40,7 @@ def options(args):
 
     return [
         ("Start Average Level", args.start_average_level),
+        ("Start Level", args.start_level),
         ("Start Naked", args.start_naked),
         ("Equipable Umaro", args.equipable_umaro),
         ("Character Stats", character_stats),

--- a/data/blitzes.py
+++ b/data/blitzes.py
@@ -15,6 +15,10 @@ class Blitzes:
 
         self.levels = DataArray(self.rom, self.LEVELS_START, self.LEVELS_END, Blitz.LEVEL_SIZE)
 
+        import data.event_bit as event_bit
+        self.can_learn_byte = 0x1e80 + event_bit.byte(event_bit.CAN_LEARN_BUM_RUSH)
+        self.can_learn_bit = 2 ** event_bit.bit(event_bit.CAN_LEARN_BUM_RUSH)
+
         self.blitzes = []
         for blitz_index in range(len(self.levels)):
             blitz = Blitz(blitz_index, self.levels[blitz_index])
@@ -50,28 +54,51 @@ class Blitzes:
         learn_blitzes = 0x0a201
         character_recruited = c0.character_recruited + START_ADDRESS_SNES
 
-        space = Allocate(Bank.C0, 24, "blitz event check", asm.NOP())
-        space.write(
+        src = [
             asm.PHA(),
             asm.JSL(character_recruited),
             asm.CMP(0x00, asm.IMM8),        # compare result with 0
             asm.BEQ("RETURN"),              # branch if character not recruited
-        )
+        ]
         if not self.args.blitzes_everyone_learns:
-            space.write(
+            src += [
                 asm.PLA(),
                 asm.PHA(),
                 asm.JSL(self.is_learner_function),
                 asm.CMP(0x00, asm.IMM8),    # compare result with 0
                 asm.BEQ("RETURN"),          # branch if character not learner
-            )
-        space.write(
+            ]
+        src += [
             asm.JSR(learn_blitzes, asm.ABS),
+
+            # when a new blitz is learned, check if 7 total now learned and if so set event bit
+            asm.PHX(),
+            asm.PHP(),
+            asm.LDA(0x1d28, asm.ABS),           # a = known blitzes
+            asm.XY8(),
+            # Sets X to number of bits set in A. So, x = number known blitzes
+            # Logic Copied from C2/520e
+            asm.LDX(0x00, asm.IMM8),
+            "LOOP_START",
+            asm.LSR(),
+            asm.BCC("BIT_NOT_SET"),
+            asm.INX(),
+            "BIT_NOT_SET",
+            asm.BNE("LOOP_START"),              # repeat loop to count all bits set in A
+            asm.CPX(0x07, asm.IMM8),            # 7 blitzes known? (total learnable except bum rush)
+            asm.BLT("DONE_7_CHECK"),        # branch if < 7 blitzes known
+            asm.LDA(self.can_learn_bit, asm.IMM8),   # load can learn bum rush bit
+            asm.TSB(self.can_learn_byte, asm.ABS),   # set can learn bum rush event bit
+
+            "DONE_7_CHECK",
+            asm.PLP(),
+            asm.PLX(),
 
             "RETURN",
             asm.PLA(),
             asm.RTS(),
-        )
+        ]
+        space = Write(Bank.C0, src, "blitz event check")
         check_blitzes = space.start_address
 
         space = Reserve(0x0a18e, 0x0a194, "event check sabin learn blitzes", asm.NOP())
@@ -122,11 +149,6 @@ class Blitzes:
 
     def blitzes_learned_event_bit(self):
         # when a new blitz is learned, check if 7 total now learned and if so set event bit
-
-        import data.event_bit as event_bit
-        can_learn_byte = 0x1e80 + event_bit.byte(event_bit.CAN_LEARN_BUM_RUSH)
-        can_learn_bit = 2 ** event_bit.bit(event_bit.CAN_LEARN_BUM_RUSH)
-
         src = [
             asm.PHX(),
             asm.PHP(),
@@ -135,8 +157,8 @@ class Blitzes:
             asm.JSR(0x520e, asm.ABS),           # x = number known blitzes
             asm.CPX(0x07, asm.IMM8),            # 7 blitzes known? (total learnable except bum rush)
             asm.BLT("RETURN"),                  # branch if < 7 blitzes known
-            asm.LDA(can_learn_bit, asm.IMM8),   # load can learn bum rush bit
-            asm.TSB(can_learn_byte, asm.ABS),   # set can learn bum rush event bit
+            asm.LDA(self.can_learn_bit, asm.IMM8),   # load can learn bum rush bit
+            asm.TSB(self.can_learn_byte, asm.ABS),   # set can learn bum rush event bit
 
             "RETURN",
             asm.PLP(),

--- a/data/characters.py
+++ b/data/characters.py
@@ -78,10 +78,11 @@ class Characters():
         return self.character_paths[character]
 
     def mod_init_levels(self):
-        if self.args.start_average_level:
-            # characters recruited at average level, set everyone's initial level to 3
-            for character in self.characters:
-                character.init_level_factor = 0
+        # remove all variation in leveling, since we're controlling level directly
+        for character in self.characters:
+            character.init_level_factor = 0
+
+        characters_asm.set_starting_level(self.args.start_level)
 
     def stats_random_percent(self):
         import random

--- a/data/characters_asm.py
+++ b/data/characters_asm.py
@@ -7,6 +7,10 @@ def equipable_umaro(character_count):
 
     space = Reserve(0x39ef4, 0x39ef7, "Reequip Umaro if genji glove/gauntlet/merit award equipped/removed", asm.NOP())
 
+def set_starting_level(start_level):
+    space = Reserve(0x09fc6, 0x09fc6, "Starting level")
+    space.write(start_level.to_bytes(1, 'little'))
+
 def update_morph_character(characters):
     from constants.commands import id_name
 


### PR DESCRIPTION
Set the characters starting level. Confirmed that Natural Magic, SwdTech, and Blitz are granted as expected. With the merged bugfix (https://github.com/AtmaTek/WorldsCollide/pull/36), Bum Rush Last also works if your character starts at >= 42.

Also confirmed that recruited characters start at the set value, unless start average level is also on.