### PR TITLE
QoL: Adding Rage Move descriptions to rage menu

### DIFF
--- a/data/enemies.py
+++ b/data/enemies.py
@@ -20,6 +20,10 @@ class Enemies():
     ITEMS_END = 0xf35ff
     ITEMS_SIZE = 4
 
+    SPECIAL_NAMES_START = 0xfd0d0
+    SPECIAL_NAMES_END = 0xfdfdf
+    SPECIAL_NAMES_SIZE = 10
+
     DRAGON_COUNT = 8
 
     SRBEHEMOTH2_ID = 127
@@ -32,11 +36,12 @@ class Enemies():
         self.enemy_data = DataArray(self.rom, self.DATA_START, self.DATA_END, self.DATA_SIZE)
         self.enemy_name_data = DataArray(self.rom, self.NAMES_START, self.NAMES_END, self.NAME_SIZE)
         self.enemy_item_data = DataArray(self.rom, self.ITEMS_START, self.ITEMS_END, self.ITEMS_SIZE)
+        self.enemy_special_name_data = DataArray(self.rom, self.SPECIAL_NAMES_START, self.SPECIAL_NAMES_END, self.SPECIAL_NAMES_SIZE)
 
         self.enemies = []
         self.bosses = []
         for enemy_index in range(len(self.enemy_data)):
-            enemy = Enemy(enemy_index, self.enemy_data[enemy_index], self.enemy_name_data[enemy_index], self.enemy_item_data[enemy_index])
+            enemy = Enemy(enemy_index, self.enemy_data[enemy_index], self.enemy_name_data[enemy_index], self.enemy_item_data[enemy_index], self.enemy_special_name_data[enemy_index])
             self.enemies.append(enemy)
 
             if enemy_index in bosses.enemy_name and enemy_index not in bosses.removed_enemy_name:
@@ -353,10 +358,12 @@ class Enemies():
             self.enemy_data[enemy_index] = self.enemies[enemy_index].data()
             self.enemy_name_data[enemy_index] = self.enemies[enemy_index].name_data()
             self.enemy_item_data[enemy_index] = self.enemies[enemy_index].item_data()
+            self.enemy_special_name_data[enemy_index] = self.enemies[enemy_index].special_name_data()
 
         self.enemy_data.write()
         self.enemy_name_data.write()
         self.enemy_item_data.write()
+        self.enemy_special_name_data.write()
 
         self.formations.write()
         self.packs.write()

--- a/data/enemy.py
+++ b/data/enemy.py
@@ -2,7 +2,7 @@ import data.text as text
 from data.status_effects import StatusEffects
 
 class Enemy:
-    def __init__(self, id, data, name_data, item_data):
+    def __init__(self, id, data, name_data, item_data, special_name_data):
         self.id = id
         self.name = text.get_string(name_data, text.TEXT2).rstrip('\0')
 
@@ -69,6 +69,8 @@ class Enemy:
         self.steal_common       = item_data[1]
         self.drop_rare          = item_data[2]
         self.drop_common        = item_data[3]
+
+        self.special_name       = text.get_string(special_name_data, text.TEXT2).rstrip('\0')
 
         # copy stats for reference after modifications
         self.original_speed         = self.speed
@@ -180,6 +182,12 @@ class Enemy:
         item_data[3]    = self.drop_common
 
         return item_data
+
+    def special_name_data(self):
+        from data.enemies import Enemies
+        data = text.get_bytes(self.special_name, text.TEXT2)
+        data.extend([0xff] * (Enemies.SPECIAL_NAMES_SIZE - len(data)))
+        return data
 
     def print(self):
         print(f"{self.id} {self.name}")

--- a/data/rages.py
+++ b/data/rages.py
@@ -1,5 +1,6 @@
 from data.rage import Rage
 from data.structures import DataBits, DataArray
+from data.ability_data import AbilityData
 
 class Rages():
     RAGE_COUNT = 256 # 255 available
@@ -14,6 +15,9 @@ class Rages():
     ATTACKS_DATA_END = 0xf47ff
     ATTACKS_DATA_SIZE = 2
 
+    ABILITY_DATA_START = 0x046ac0
+    ABILITY_DATA_END = 0x0478bf
+
     def __init__(self, rom, args, enemies):
         self.rom = rom
         self.args = args
@@ -21,11 +25,17 @@ class Rages():
 
         self.init_data = DataBits(self.rom, self.INITIAL_RAGES_START, self.INITIAL_RAGES_END)
         self.attack_data = DataArray(self.rom, self.ATTACKS_DATA_START, self.ATTACKS_DATA_END, self.ATTACKS_DATA_SIZE)
+        self.ability_data = DataArray(self.rom, self.ABILITY_DATA_START, self.ABILITY_DATA_END, AbilityData.DATA_SIZE)
 
         self.rages = []
         for rage_index in range(len(self.attack_data)):
             rage = Rage(rage_index, self.attack_data[rage_index])
             self.rages.append(rage)
+
+        self.abilities = []
+        for ability_index in range(len(self.ability_data)):
+            ability = AbilityData(ability_index, self.ability_data[ability_index])
+            self.abilities.append(ability)
 
     def start_random_rages(self):
         import random

--- a/menus/menus.py
+++ b/menus/menus.py
@@ -9,16 +9,17 @@ import menus.coliseum as coliseum
 import menus.sell as sell
 
 class Menus:
-    def __init__(self, characters, dances, rages):
+    def __init__(self, characters, dances, rages, enemies):
         self.characters = characters
         self.dances = dances
         self.rages = rages
+        self.enemies = enemies
 
         self.pregame_track = pregame_track.PreGameTrack(self.characters)
         self.pregame_menu = pregame.PreGameMenu(self.pregame_track)
         self.track_menu = track.TrackMenu(self.pregame_track)
         self.dance_menu = dance.DanceMenu(self.dances)
-        self.rage_menu = rage.RageMenu(self.rages)
+        self.rage_menu = rage.RageMenu(self.rages, self.enemies)
         self.status_menu = status.StatusMenu(self.characters)
         self.final_lineup_menu = final_lineup.FinalLineupMenu(self.characters)
         self.coliseum_menu = coliseum.ColiseumMenu()

--- a/menus/menus.py
+++ b/menus/menus.py
@@ -2,20 +2,23 @@ import menus.pregame_track as pregame_track
 import menus.pregame as pregame
 import menus.track as track
 import menus.dance as dance
+import menus.rage as rage
 import menus.status as status
 import menus.final_lineup as final_lineup
 import menus.coliseum as coliseum
 import menus.sell as sell
 
 class Menus:
-    def __init__(self, characters, dances):
+    def __init__(self, characters, dances, rages):
         self.characters = characters
         self.dances = dances
+        self.rages = rages
 
         self.pregame_track = pregame_track.PreGameTrack(self.characters)
         self.pregame_menu = pregame.PreGameMenu(self.pregame_track)
         self.track_menu = track.TrackMenu(self.pregame_track)
         self.dance_menu = dance.DanceMenu(self.dances)
+        self.rage_menu = rage.RageMenu(self.rages)
         self.status_menu = status.StatusMenu(self.characters)
         self.final_lineup_menu = final_lineup.FinalLineupMenu(self.characters)
         self.coliseum_menu = coliseum.ColiseumMenu()

--- a/menus/rage.py
+++ b/menus/rage.py
@@ -32,13 +32,10 @@ class RageMenu:
         self.special_effects.append("Drain MP")
         self.special_effects.append("Remove Reflect")
 
-        self.element_strings = ["<fire>", "<ice>", "<lightning>", "<poison>", "<wind>", "<pearl>", "<earth>", "<water>"] # in bit order for spell.element
-
         self.mod()
 
     def get_rage_string(self, id, attack_id):
         from data.spell_names import id_name, name_id
-
 
         if attack_id == name_id["Special"]:
             # handle special name lookup + special attack info (dmg multipler, status effect)
@@ -48,92 +45,12 @@ class RageMenu:
 
             rage_str = f"{special_name}: "
             rage_str += self.special_effects[special_effect]
-        elif attack_id == name_id["Pep Up"]:
-            rage_str = "Pep Up: Remove Caster+Heal Ally"
-        elif attack_id == name_id["Flare Star"]:
-            rage_str = "Flare Star: <fire> E.Lvl*80 IgnDef<line>All Enemies"
-        elif attack_id == name_id["Dischord"]:
-            rage_str = "Dischord: Halve Enemy Level"
-        elif attack_id == name_id["Revenge"]:
-            rage_str = "Revenge: dmg = Max - Curr.HP"
-        elif attack_id == name_id["Blow Fish"]:
-            rage_str = "Blow Fish: 1000 dmg"
-        elif attack_id == name_id["Pearl Wind"]:
-            rage_str = "Pearl Wind: Heal Curr.HP<line>Party"
-        elif attack_id == name_id["Step Mine"]:
-            rage_str = "Step Mine: dmg = Steps/32"
         else:
             rage_str = f"{id_name[attack_id]}"
-
-            ability = self.rages.abilities[attack_id]
-            ability_details = ""
-
-            # Add the element graphic to the rage string for any element bits that are set
-            spell_elements = ability.elements
-            for bit in range(0,8):
-                if (spell_elements >> bit) & 1:
-                    ability_details += self.element_strings[bit]
-            if (ability.status1 & 0x80) and (ability.flags1 & 0x02): # Instant-death effect
-                ability_details += "<death>"
-
-            if ability.power > 1: # Ignoring 1, which includes special damage skills like Exploder & Blow Fish
-                if ability_details != "":
-                    ability_details += " "
-
-                if ability.flags3 & 0x80: # fractional damage
-                    from fractions import Fraction
-                    hp_fraction = Fraction(ability.power/16)
-                    ability_details += f"{str(hp_fraction)} HP"
-                else:
-                    ability_details += f"{ability.power}"
-                    if (ability.flags1 & 1):
-                        # Physical damage
-                        ability_details += "P"
-                    else:
-                        # Magic damage
-                        ability_details += "M"
-                    ability_details += "Pwr"
-
-                    if ability.flags1 & 0x20: #ignore def
-                        ability_details += " IgnDef"
-
-            # Add status effects
-            offset = 0
-            bits_set = 0
-            status_details = " "
-            statuses = [ability.status1, ability.status2, ability.status3, ability.status4]
-            for status in statuses:
-                for bit in range(0,8):
-                    if(status >> bit) & 1:
-                        status_details += f"{self.status_effects[offset + bit]} "
-                        bits_set += 1
-                offset += 8
-            if bits_set > 2:
-                # we only have room to show 2 statuses
-                status_details = " Multi-Status"
-            ability_details += status_details
-
-            # Indicate multi-target spells
-            if ability.targets & 0x08: # Select One Group flag 
-                if ability.targets & 0x40: # Enemy selected
-                    ability_details += "<line>All Enemies"
-                else:
-                    ability_details += "<line>Party"
-            elif ability.targets & 0x04: # Select all targets (both groups)
-                ability_details += "<line>All"
-
-            # Add ability_details to rage_string if it's not empty and the description doesn't match the name
-            if ability_details.strip() != "" and ability_details.strip() != id_name[attack_id]:
-                rage_str += f": {ability_details}"
 
         # # remove duplicate white spaces
         import re
         rage_str = re.sub(' +', ' ', rage_str)
-
-        # add a space after <poison> due to it overlapping to the right
-        rage_str = rage_str.replace("<poison>", "<poison> ")
-        # remove spaces before <line>
-        rage_str = rage_str.replace(" <line>", "<line>")
 
         # remove leading and trailing spaces
         rage_str = rage_str.strip()

--- a/menus/rage.py
+++ b/menus/rage.py
@@ -1,8 +1,6 @@
 from memory.space import Bank, Reserve, Allocate, Write
 import instruction.asm as asm
 
-# Testing with 
-# py wc.py -i ../rom/ff3.sfc -sc1 terra -com 16989898989898989898989898 -srr 255 255
 class RageMenu:
     def __init__(self, rages):
         self.rages = rages
@@ -11,6 +9,7 @@ class RageMenu:
 
     def draw_ability_names_mod(self):
         import data.text as text
+        from data.spell_names import name_id
 
         rage_data_address = self.rages.ATTACKS_DATA_START + 0xc00000
 
@@ -27,12 +26,12 @@ class RageMenu:
         space = Write(Bank.C3, src, "draw comma & space")
         draw_comma_space = space.start_address
 
-        # argument: x = rage data index
+        # argument: a = rage ability ID
         # returns:  y = length of string, x = pointer to string
         # Based in part on https://github.com/FF6BeyondChaos/BeyondChaosRandomizer/blob/082695ebcb7e817dee5b2a778a4620963af5a4df/BeyondChaos/menufeatures.py#L77
-        index_in_ram = 0x38 # RAM variable
+        ability_id_in_ram = 0x38      # RAM variable (1 byte)
+        rage_idx_in_ram = 0xE0        # RAM variable (2 bytes)
         src = [
-            asm.LDA(rage_data_address, asm.LNG_X),   # a = ability id
             asm.CMP(0x36, asm.IMM8),                 # less than 54? It's a spell with length 7
             asm.BCC("GET_7_CHAR_SPELL_NAME"),
             asm.CMP(0x51, asm.IMM8),                 # else if less than 81? It's an esper with length 8
@@ -43,11 +42,12 @@ class RageMenu:
             asm.SBC(0x51, asm.IMM8),
             asm.A16(),
             asm.AND(0x00ff, asm.IMM16),
-            asm.STA(index_in_ram, asm.ABS), 
+            asm.STA(ability_id_in_ram, asm.ABS), 
             asm.ASL(),
             asm.ASL(),
-            asm.ADC(index_in_ram, asm.ABS),
-            asm.ASL(),
+            asm.CLC(),
+            asm.ADC(ability_id_in_ram, asm.ABS),
+            asm.ASL(), # A *= 10
             asm.ADC(0x252, asm.IMM16),  # start of attack name - 0x26f567
             asm.TAX(),
             asm.LDY(0x000a, asm.IMM16),  # 10 characters
@@ -56,12 +56,12 @@ class RageMenu:
             "GET_7_CHAR_SPELL_NAME",
             asm.A16(),
             asm.AND(0x00ff, asm.IMM16),
-            asm.STA(index_in_ram, asm.ABS), 
+            asm.STA(ability_id_in_ram, asm.ABS), 
             asm.ASL(),
             asm.ASL(),
             asm.ASL(),  # A *= 8
             asm.SEC(),
-            asm.SBC(index_in_ram, asm.DIR), # change it to A *= 7
+            asm.SBC(ability_id_in_ram, asm.DIR), # change it to A *= 7
             asm.TAX(),
             asm.LDY(0x0007, asm.IMM16),  # 7 character length
             asm.A8(),
@@ -88,8 +88,34 @@ class RageMenu:
             asm.PHX(),
             asm.PHY(),
 
+            # "Special" ability logic to get the name of the special ability
+            asm.LDA(rage_data_address, asm.LNG_X), # a = ability id
+            asm.CMP(name_id["Special"], asm.IMM8), # is this a Special ability?
+            asm.BNE("GET_ABILITY_NAME"),           # if not, get the name of the ability
+            # else, get the Special name instead from 0fd0d0 + rage_idx * 10, length 10
+            asm.LDY(0x000a, asm.IMM16),  # 10 characters
+            asm.LDA(rage_idx_in_ram, asm.ABS), # rage_idx
+            asm.A16(),
+            asm.AND(0x00ff, asm.IMM16),
+            asm.ASL(),
+            asm.ASL(),
+            asm.CLC(),
+            asm.ADC(rage_idx_in_ram, asm.ABS),
+            asm.ASL(), # A *= 10
+            asm.TAX(),
+            asm.A8(),
+            "SPECIAL_NAME_LOOP_START",
+            # x = offset from start of special names (0fd0d0), y = length (10)
+            asm.LDA(0x0fd0d0, asm.LNG_X),           # a = current char in special name
+            asm.CMP(space_value, asm.IMM8),         # compare with character ' ' which pads end of ability names
+            asm.BEQ("DRAW_ABILITY_NAME_RETURN"),    # branch if reached end of special name
+            asm.STA(0x2180, asm.ABS),               # add character to string
+            asm.INX(),                              # next character in special name
+            asm.DEY(),                              # decrement special name character index
+            asm.BNE("SPECIAL_NAME_LOOP_START"),     # branch if not zero
+            asm.BRA("DRAW_ABILITY_NAME_RETURN"),    # else, done
+            "GET_ABILITY_NAME",
             asm.JSR(get_ability_name, asm.ABS),
-
             # x = offset from start of ability names (26f567), y = length
             "ABILITY_NAME_LOOP_START",
             asm.LDA(0x26f567, asm.LNG_X),           # a = current char in ability name
@@ -99,7 +125,6 @@ class RageMenu:
             asm.INX(),                              # next character in ability name
             asm.DEY(),                              # decrement ability name character index
             asm.BNE("ABILITY_NAME_LOOP_START"),     # branch if not zero
-
             "DRAW_ABILITY_NAME_RETURN",
             asm.PLY(),
             asm.PLX(),
@@ -120,6 +145,7 @@ class RageMenu:
             asm.BEQ("END_STRING_RETURN"),   # branch if rage at cursor index not learned
 
             asm.A16(),
+            asm.STA(rage_idx_in_ram, asm.ABS), # store the rage_idx, as it aligns with the monster index elsewhere to lookup Special abilities
             asm.ASL(),                      # a = rage index * 2 (2 abilities per rage)
             asm.TAX(),                      # x = rage index * 2 (rage ability data index)
             asm.TDC(),                      # clear A of any 16-bit remnants

--- a/menus/rage.py
+++ b/menus/rage.py
@@ -1,0 +1,159 @@
+from memory.space import Bank, Reserve, Allocate, Write
+import instruction.asm as asm
+
+# Testing with 
+# py wc.py -i ../rom/ff3.sfc -sc1 terra -com 16989898989898989898989898 -srr 255 255
+class RageMenu:
+    def __init__(self, rages):
+        self.rages = rages
+
+        self.mod()
+
+    def draw_ability_names_mod(self):
+        import data.text as text
+
+        rage_data_address = self.rages.ATTACKS_DATA_START + 0xc00000
+
+        comma_value = int.from_bytes(text.get_bytes(',', text.TEXT3), "little")
+        space_value = int.from_bytes(text.get_bytes(' ', text.TEXT3), "little")
+
+        src = [
+            asm.LDA(comma_value, asm.IMM8), # load ',' character
+            asm.STA(0x2180, asm.ABS),       # add ',' to string
+            asm.LDA(space_value, asm.IMM8), # load ' ' character
+            asm.STA(0x2180, asm.ABS),       # add ' ' to string
+            asm.RTS(),
+        ]
+        space = Write(Bank.C3, src, "draw comma & space")
+        draw_comma_space = space.start_address
+
+        # argument: x = rage data index
+        # returns:  y = length of string, x = pointer to string
+        # Based in part on https://github.com/FF6BeyondChaos/BeyondChaosRandomizer/blob/082695ebcb7e817dee5b2a778a4620963af5a4df/BeyondChaos/menufeatures.py#L77
+        index_in_ram = 0x38 # RAM variable
+        src = [
+            asm.LDA(rage_data_address, asm.LNG_X),   # a = ability id
+            asm.CMP(0x36, asm.IMM8),                 # less than 54? It's a spell with length 7
+            asm.BCC("GET_7_CHAR_SPELL_NAME"),
+            asm.CMP(0x51, asm.IMM8),                 # else if less than 81? It's an esper with length 8
+            asm.BCC("GET_8_CHAR_ESPER_NAME"),
+            # else, it's greater than 81; it's an ability with length 10
+            "GET_10_CHAR_ABILITY_NAME",
+            asm.SEC(),
+            asm.SBC(0x51, asm.IMM8),
+            asm.A16(),
+            asm.AND(0x00ff, asm.IMM16),
+            asm.STA(index_in_ram, asm.ABS), 
+            asm.ASL(),
+            asm.ASL(),
+            asm.ADC(index_in_ram, asm.ABS),
+            asm.ASL(),
+            asm.ADC(0x252, asm.IMM16),  # start of attack name - 0x26f567
+            asm.TAX(),
+            asm.LDY(0x000a, asm.IMM16),  # 10 characters
+            asm.A8(),
+            asm.RTS(),
+            "GET_7_CHAR_SPELL_NAME",
+            asm.A16(),
+            asm.AND(0x00ff, asm.IMM16),
+            asm.STA(index_in_ram, asm.ABS), 
+            asm.ASL(),
+            asm.ASL(),
+            asm.ASL(),  # A *= 8
+            asm.SEC(),
+            asm.SBC(index_in_ram, asm.DIR), # change it to A *= 7
+            asm.TAX(),
+            asm.LDY(0x0007, asm.IMM16),  # 7 character length
+            asm.A8(),
+            asm.RTS(),
+            "GET_8_CHAR_ESPER_NAME",
+            asm.SEC(),
+            asm.SBC(0x36, asm.IMM8),
+            asm.A16(),
+            asm.AND(0x00ff, asm.IMM16),
+            asm.ASL(),
+            asm.ASL(),
+            asm.ASL(),  # A *= 8
+            asm.ADC(0x17a, asm.IMM16),    # start of esper name - 0x26f567
+            asm.TAX(),
+            asm.LDY(0x0008, asm.IMM16),  # 8 character length
+            asm.A8(),
+            asm.RTS(),
+        ]
+        space = Write(Bank.C3, src, "get ability name")
+        get_ability_name = space.start_address
+
+        # argument: x = rage data index
+        src = [
+            asm.PHX(),
+            asm.PHY(),
+
+            asm.JSR(get_ability_name, asm.ABS),
+
+            # x = offset from start of ability names (26f567), y = length
+            "ABILITY_NAME_LOOP_START",
+            asm.LDA(0x26f567, asm.LNG_X),           # a = current char in ability name
+            asm.CMP(space_value, asm.IMM8),         # compare with character ' ' which pads end of ability names
+            asm.BEQ("DRAW_ABILITY_NAME_RETURN"),    # branch if reached end of ability name
+            asm.STA(0x2180, asm.ABS),               # add character to string
+            asm.INX(),                              # next character in ability name
+            asm.DEY(),                              # decrement ability name character index
+            asm.BNE("ABILITY_NAME_LOOP_START"),     # branch if not zero
+
+            "DRAW_ABILITY_NAME_RETURN",
+            asm.PLY(),
+            asm.PLX(),
+            asm.RTS(),
+        ]
+        space = Write(Bank.C3, src, "draw ability name")
+        draw_ability_name = space.start_address
+
+        src = [
+            asm.LDX(0x9ec9, asm.IMM16),     # dest WRAM LBs
+            asm.STX(0x2181, asm.ABS),       # store dest WRAM LBs
+
+            asm.TDC(),                      # a = 0x0000
+            asm.LDA(0x4b, asm.DIR),         # a = cursor index (rage index)
+            asm.TAX(),                      # x = cursor index (rage index)
+            asm.LDA(0x7e9d89, asm.LNG_X),   # a = rage at cursor index
+            asm.CMP(0xff, asm.IMM8),        # compare with no rage
+            asm.BEQ("END_STRING_RETURN"),   # branch if rage at cursor index not learned
+
+            asm.A16(),
+            asm.ASL(),                      # a = rage index * 2 (2 abilities per rage)
+            asm.TAX(),                      # x = rage index * 2 (rage ability data index)
+            asm.TDC(),                      # clear A of any 16-bit remnants
+            asm.A8(),
+            asm.JSR(draw_ability_name, asm.ABS),    # draw current ability
+            asm.JSR(draw_comma_space, asm.ABS),     # draw ', ' separator
+            asm.INX(),                              # next ability
+            asm.JSR(draw_ability_name, asm.ABS),    # draw current ability
+
+            "END_STRING_RETURN",
+            asm.STZ(0x2180, asm.ABS),       # end string
+            asm.RTS(),
+        ]
+        space = Write(Bank.C3, src, "draw ability names")
+        draw_ability_names = space.start_address
+
+        sustain_replace = 0x328c6   # handle L and R
+        replace_size = 3            # replacing jsr instructions
+
+        src = [
+            asm.LDA(0x10, asm.IMM8),# enable description menu flag bitmask
+            asm.TRB(0x45, asm.DIR), # enable descriptions
+            asm.JSR(0x4c52, asm.ABS),  # displaced code: handle D-Pad
+            asm.JMP(draw_ability_names, asm.ABS),
+        ]
+        space = Write(Bank.C3, src, "sustain rage list")
+        sustain_rage_list = space.start_address
+
+        print(f"{space.start_address_snes:x}")
+
+        space = Reserve(sustain_replace, sustain_replace + replace_size - 1, "rage menu sustain handle D-Pad")
+        space.write(
+            asm.JSR(sustain_rage_list, asm.ABS),
+        )
+
+    def mod(self):
+        self.draw_ability_names_mod()

--- a/menus/rage.py
+++ b/menus/rage.py
@@ -1,149 +1,132 @@
 from memory.space import Bank, Reserve, Allocate, Write
 import instruction.asm as asm
+from data.spell_names import name_id, id_name
+
 
 class RageMenu:
-    def __init__(self, rages):
+    def __init__(self, rages, enemies):
         self.rages = rages
+        self.enemies = enemies
+
+        # Build an array to lookup enemy-specific Special command effects
+        from constants.status_effects import A, B, C, D
+        self.status_effects = []
+        self.status_effects.extend(list(A.id_name.values()))
+        self.status_effects.extend(list(B.id_name.values()))
+        self.status_effects.extend(list(C.id_name.values()))
+        self.status_effects.extend(list(D.id_name.values()))
+
+        # Remove death from the status effects list, as it requires a second bit from flags1 
+        self.status_effects = list(map(lambda x: x.replace("Death", ""), self.status_effects))
+
+        self.special_effects = []  
+        self.special_effects.extend(self.status_effects)
+        for i in range(15, 95, 5): # going from 1.5x - 9.0x damage
+            dmg_multiplier = i / 10
+            self.special_effects.append(f"{dmg_multiplier:.1f}x dmg")
+        self.special_effects.append("Drain HP")
+        self.special_effects.append("Drain MP")
+        self.special_effects.append("Remove Reflect")
+
+        # Note: Space after <poison> is intentional, as that graphic overlaps to the right otherwise
+        self.element_strings = ["<fire>", "<ice>", "<lightning>", "<poison> ", "<wind>", "<pearl>", "<earth>", "<water>"] # in bit order for spell.element
 
         self.mod()
 
+    def get_rage_string(self, id, attack_id):
+        from data.spell_names import id_name, name_id
+
+        if(attack_id != name_id["Special"]):
+            rage_str = f"{id_name[attack_id]}"
+
+            ability = self.rages.abilities[attack_id]
+            ability_details = ""
+
+            # Add the element graphic to the rage string for any element bits that are set
+            spell_elements = ability.elements
+            for bit in range(0,8):
+                if (spell_elements >> bit) & 1:
+                    ability_details += self.element_strings[bit]
+            if (ability.status1 & 0x80) and (ability.flags1 & 0x02): # Instant-death effect
+                ability_details += "<death>"
+
+            if ability.power > 1: # Ignoring 1, which includes special damage skills like Exploder & Blow Fish
+                if ability_details != "":
+                    ability_details += " "
+
+                if ability.flags3 & 0x80: # fractional damage
+                    ability_details += f"{ability.power}/16 HP"
+                else:
+                    ability_details += f"{ability.power}"
+                    if (ability.flags1 & 1):
+                        # Physical damage
+                        ability_details += "P"
+                    else:
+                        # Magic damage
+                        ability_details += "M"
+                    ability_details += "Pwr"
+
+            if ability_details == "":
+                # if the ability details are blank (meaning we have room) and there are status effects associated with this, add them
+                offset = 0
+                bits_set = 0
+                status_details = ""
+                statuses = [ability.status1, ability.status2, ability.status3, ability.status4]
+                for status in statuses:
+                    for bit in range(0,8):
+                        if(status >> bit) & 1:
+                            status_details += f"{self.status_effects[offset + bit]} "
+                            bits_set += 1
+                    offset += 8
+                if bits_set > 2:
+                    # we only have room to show 2 statuses
+                    status_details = "Multi-Status"
+                ability_details += status_details
+
+            if ability_details != "":
+                rage_str += f": {ability_details}"
+            
+            
+        else:
+            # handle special name lookup + special attack info (dmg multipler, status effect)
+            enemy = self.enemies.enemies[id]
+            special_name = enemy.special_name
+            special_effect = enemy.special_effect
+
+            rage_str = f"{special_name}: "
+            rage_str += self.special_effects[special_effect]
+
+        return rage_str
+
     def draw_ability_names_mod(self):
         import data.text as text
-        from data.spell_names import name_id
-        from data.text import text2
 
-        rage_data_address = self.rages.ATTACKS_DATA_START + 0xc00000
+        # Get the custom strings for each rage to be written to the ROM
+        lines = []
+        for rage in self.rages.rages:
+            # Only focusing on attack2, as attack1 is simply "Battle" -- if that changes in the future, this string can be revisited
+            rage_str = f"{self.get_rage_string(rage.id, rage.attack2)}<end>"
+            lines.append(rage_str)
 
-        comma_value = int.from_bytes(text.get_bytes(',', text.TEXT3), "little")
-        space_value = int.from_bytes(text.get_bytes(' ', text.TEXT3), "little")
+        line_offsets = [0]
+        running_offset = 0
+        # Write the lines to F0
+        src = []
+        for line in lines:
+            # convert to bytes
+            bytes = text.get_bytes(line, text.TEXT3)
+            running_offset += len(bytes)
+            line_offsets.append(running_offset)
+            src.append(bytes)
+        space = Write(Bank.F0, src, "rage description lines table")
+        lines_table = space.start_address_snes
 
-        src = [
-            asm.LDA(comma_value, asm.IMM8), # load ',' character
-            asm.STA(0x2180, asm.ABS),       # add ',' to string
-            asm.LDA(space_value, asm.IMM8), # load ' ' character
-            asm.STA(0x2180, asm.ABS),       # add ' ' to string
-            asm.RTS(),
-        ]
-        space = Write(Bank.C3, src, "draw comma & space")
-        draw_comma_space = space.start_address
-
-        # argument: a = rage ability ID
-        # returns:  y = length of string, x = pointer to string
-        # Based in part on https://github.com/FF6BeyondChaos/BeyondChaosRandomizer/blob/082695ebcb7e817dee5b2a778a4620963af5a4df/BeyondChaos/menufeatures.py#L77
-        ability_id_in_ram = 0x38      # RAM variable (1 byte)
-        rage_idx_in_ram = 0xE0        # RAM variable (2 bytes)
-        src = [
-            asm.CMP(0x36, asm.IMM8),                 # less than 54? It's a spell with length 7
-            asm.BCC("GET_7_CHAR_SPELL_NAME"),
-            asm.CMP(0x51, asm.IMM8),                 # else if less than 81? It's an esper with length 8
-            asm.BCC("GET_8_CHAR_ESPER_NAME"),
-            # else, it's greater than 81; it's an ability with length 10
-            "GET_10_CHAR_ABILITY_NAME",
-            asm.SEC(),
-            asm.SBC(0x51, asm.IMM8),
-            asm.A16(),
-            asm.AND(0x00ff, asm.IMM16),
-            asm.STA(ability_id_in_ram, asm.ABS), 
-            asm.ASL(),
-            asm.ASL(),
-            asm.CLC(),
-            asm.ADC(ability_id_in_ram, asm.ABS),
-            asm.ASL(), # A *= 10
-            asm.ADC(0x252, asm.IMM16),  # start of attack name - 0x26f567
-            asm.TAX(),
-            asm.LDY(0x000a, asm.IMM16),  # 10 characters
-            asm.A8(),
-            asm.RTS(),
-            "GET_7_CHAR_SPELL_NAME",
-            asm.A16(),
-            asm.AND(0x00ff, asm.IMM16),
-            asm.STA(ability_id_in_ram, asm.ABS), 
-            asm.ASL(),
-            asm.ASL(),
-            asm.ASL(),  # A *= 8
-            asm.SEC(),
-            asm.SBC(ability_id_in_ram, asm.DIR), # change it to A *= 7
-            asm.TAX(),
-            asm.LDY(0x0007, asm.IMM16),  # 7 character length
-            asm.A8(),
-            asm.RTS(),
-            "GET_8_CHAR_ESPER_NAME",
-            asm.SEC(),
-            asm.SBC(0x36, asm.IMM8),
-            asm.A16(),
-            asm.AND(0x00ff, asm.IMM16),
-            asm.ASL(),
-            asm.ASL(),
-            asm.ASL(),  # A *= 8
-            asm.ADC(0x17a, asm.IMM16),    # start of esper name - 0x26f567
-            asm.TAX(),
-            asm.LDY(0x0008, asm.IMM16),  # 8 character length
-            asm.A8(),
-            asm.RTS(),
-        ]
-        space = Write(Bank.C3, src, "get ability name")
-        get_ability_name = space.start_address
-
-        # argument: x = rage data index
-        src = [
-            asm.PHX(),
-            asm.PHY(),
-
-            # "Special" ability logic to get the name of the special ability
-            asm.LDA(rage_data_address, asm.LNG_X), # a = ability id
-            asm.CMP(name_id["Special"], asm.IMM8), # is this a Special ability?
-            asm.BNE("GET_ABILITY_NAME"),           # if not, get the name of the ability
-            # else, get the Special name instead from 0fd0d0 + rage_idx * 10, length 10
-            asm.LDY(0x000a, asm.IMM16),  # 10 characters
-            asm.LDA(rage_idx_in_ram, asm.ABS), # rage_idx
-            asm.A16(),
-            asm.AND(0x00ff, asm.IMM16),
-            asm.ASL(),
-            asm.ASL(),
-            asm.CLC(),
-            asm.ADC(rage_idx_in_ram, asm.ABS),
-            asm.ASL(), # A *= 10
-            asm.TAX(),
-            asm.A8(),
-            # Write a ! to indicate it's a special attack
-            asm.LDA(text2.text_value['!'], asm.IMM8),
-            asm.STA(0x2180, asm.ABS),
-            "SPECIAL_NAME_LOOP_START",
-            # x = offset from start of special names (0fd0d0), y = length (10)
-            asm.LDA(0x0fd0d0, asm.LNG_X),           # a = current char in special name
-            asm.CMP(space_value, asm.IMM8),         # compare with character ' ' which pads end of ability names
-            asm.BEQ("DRAW_ABILITY_NAME_RETURN"),    # branch if reached end of special name
-            asm.STA(0x2180, asm.ABS),               # add character to string
-            asm.INX(),                              # next character in special name
-            asm.DEY(),                              # decrement special name character index
-            asm.BNE("SPECIAL_NAME_LOOP_START"),     # branch if not zero
-            asm.BRA("DRAW_ABILITY_NAME_RETURN"),    # else, done
-            "GET_ABILITY_NAME",
-            asm.JSR(get_ability_name, asm.ABS),
-            # x = offset from start of ability names (26f567), y = length
-            "ABILITY_NAME_LOOP_START",
-            asm.LDA(0x26f567, asm.LNG_X),           # a = current char in ability name
-            asm.CMP(space_value, asm.IMM8),         # compare with character ' ' which pads end of ability names
-            asm.BEQ("DRAW_ABILITY_NAME_RETURN"),    # branch if reached end of ability name
-            # skip over magic icons, which don't show up with the variable-width font used
-            asm.CMP(text2.text_value['<white magic icon>'], asm.IMM8),
-            asm.BEQ("NEXT_CHARACTER"),
-            asm.CMP(text2.text_value['<black magic icon>'], asm.IMM8),
-            asm.BEQ("NEXT_CHARACTER"),
-            asm.CMP(text2.text_value['<gray magic icon>'], asm.IMM8),
-            asm.BEQ("NEXT_CHARACTER"),
-            asm.STA(0x2180, asm.ABS),               # add character to string
-            "NEXT_CHARACTER",
-            asm.INX(),                              # next character in ability name
-            asm.DEY(),                              # decrement ability name character index
-            asm.BNE("ABILITY_NAME_LOOP_START"),     # branch if not zero
-            "DRAW_ABILITY_NAME_RETURN",
-            asm.PLY(),
-            asm.PLX(),
-            asm.RTS(),
-        ]
-        space = Write(Bank.C3, src, "draw ability name")
-        draw_ability_name = space.start_address
+        # write the 2-byte line offsets to F0
+        src = []
+        for offset in line_offsets:
+            src.append(offset.to_bytes(2, 'little'))
+        space = Write(Bank.F0, src, "rage description lines table offsets")
+        lines_table_offsets = space.start_address_snes
 
         src = [
             asm.LDX(0x9ec9, asm.IMM16),     # dest WRAM LBs
@@ -155,20 +138,22 @@ class RageMenu:
             asm.LDA(0x7e9d89, asm.LNG_X),   # a = rage at cursor index
             asm.CMP(0xff, asm.IMM8),        # compare with no rage
             asm.BEQ("END_STRING_RETURN"),   # branch if rage at cursor index not learned
-
             asm.A16(),
-            asm.STA(rage_idx_in_ram, asm.ABS), # store the rage_idx, as it aligns with the monster index elsewhere to lookup Special abilities
-            asm.ASL(),                      # a = rage index * 2 (2 abilities per rage)
-            asm.TAX(),                      # x = rage index * 2 (rage ability data index)
-            asm.TDC(),                      # clear A of any 16-bit remnants
+            asm.ASL(),                      # a = rage index * 2 (2 bytes per table offset)
+            asm.TAX(),                      # x = rage index * 2 
+            asm.LDA(lines_table_offsets, asm.LNG_X), # get the offset
+            asm.TAX(),
             asm.A8(),
-            asm.JSR(draw_ability_name, asm.ABS),    # draw current ability
-            asm.JSR(draw_comma_space, asm.ABS),     # draw ', ' separator
-            asm.INX(),                              # next ability
-            asm.JSR(draw_ability_name, asm.ABS),    # draw current ability
-
+            "STRING_LOOP_START",
+            asm.LDA(lines_table, asm.LNG_X), # get the character
+            asm.STA(0x2180, asm.ABS),        # add character to string
+            asm.CMP(0x00, asm.IMM8),         # was it the end of the string? 
+            asm.BEQ("RETURN"),               # if so, be done
+            asm.INX(),                       # move to next character in ability name
+            asm.BRA("STRING_LOOP_START"),    
             "END_STRING_RETURN",
             asm.STZ(0x2180, asm.ABS),       # end string
+            "RETURN",
             asm.RTS(),
         ]
         space = Write(Bank.C3, src, "draw ability names")
@@ -185,8 +170,6 @@ class RageMenu:
         ]
         space = Write(Bank.C3, src, "sustain rage list")
         sustain_rage_list = space.start_address
-
-        print(f"{space.start_address_snes:x}")
 
         space = Reserve(sustain_replace, sustain_replace + replace_size - 1, "rage menu sustain handle D-Pad")
         space.write(

--- a/wc.py
+++ b/wc.py
@@ -12,7 +12,7 @@ def main():
     events = Events(memory.rom, args, data)
 
     from menus.menus import Menus
-    menus = Menus(data.characters, data.dances)
+    menus = Menus(data.characters, data.dances, data.rages)
 
     from battle import Battle
     battle = Battle()

--- a/wc.py
+++ b/wc.py
@@ -12,7 +12,7 @@ def main():
     events = Events(memory.rom, args, data)
 
     from menus.menus import Menus
-    menus = Menus(data.characters, data.dances, data.rages)
+    menus = Menus(data.characters, data.dances, data.rages, data.enemies)
 
     from battle import Battle
     battle = Battle()


### PR DESCRIPTION
Tested with `py wc.py -i ../rom/ff3.sfc -sc1 terra -com 16989898989898989898989898 -srr 255 255`

Confirmed all vanilla rages appear correctly. Example:

![image](https://user-images.githubusercontent.com/96998881/199843045-dc2101a9-f6b6-40c3-a183-d335409959a7.png)
