### PR TITLE
Feature: Adding Auto Life 3 and Auto Dog Block objective results

### DIFF
--- a/battle/auto_status.py
+++ b/battle/auto_status.py
@@ -9,12 +9,15 @@ class _AutoStatus:
     def __init__(self):
         auto_b_status_effects = ["Condemned", "Image", "Mute", "Berserk", "Muddle", "Seizure", "Sleep"]
         auto_c_status_effects = ["Float", "Regen", "Slow", "Haste", "Shell", "Safe", "Reflect"]
+        auto_d_status_effects = ["Life 3", "Dog Block"]
 
         auto_addresses = []
         for status in auto_b_status_effects:
             auto_addresses.append(self.auto_status(status, status_effects.B))
         for status in auto_c_status_effects:
             auto_addresses.append(self.auto_status(status, status_effects.C))
+        for status in auto_d_status_effects:
+            auto_addresses.append(self.auto_status(status, status_effects.D))
 
         src = [
             # original replaced code
@@ -40,8 +43,11 @@ class _AutoStatus:
             asm.JSL(START_ADDRESS_SNES + auto_status_effects),
         )
 
+        # Ensure that Life 3 can also be applied at the start of battle
+        space = Reserve(0x22823, 0x22823, "Only keep Dog Block and Float")
+        space.write(0xC4) # Original: 0xC0; also keeping Life 3
+
     def auto_status(self, status_name, status_effects_group):
-        status_name = status_name.capitalize()
         auto_status_name = "Auto " + status_name
         auto_status_name_upper = auto_status_name.upper()
 
@@ -51,8 +57,13 @@ class _AutoStatus:
             status_bit = 1 << status_effects_group.name_id[status_name]
         if status_effects_group == status_effects.B:
             status_address = 0x3c6c
+            opcode = asm.ABS_X
         elif status_effects_group == status_effects.C:
             status_address = 0x3c6d
+            opcode = asm.ABS_X
+        elif status_effects_group == status_effects.D:
+            status_address = 0x1615 
+            opcode = asm.ABS_Y
 
         src = []
         if auto_status_name in objectives.results:
@@ -71,9 +82,26 @@ class _AutoStatus:
             asm.RTS(),
 
             auto_status_name_upper,
-            asm.LDA(status_address, asm.ABS_X),
+        ]
+        
+        # if the opcode is Y, that means we're accessing the SRAM offset, for which Y is multiples of 37
+        if(opcode == asm.ABS_Y):
+            src += [
+                asm.PHY(), # push current Y
+                asm.XY16(), # 16-bit X & Y
+                asm.LDY(0x3010, asm.ABS_X) # get the pointer to the character
+            ]
+        src += [
+            asm.LDA(status_address, opcode),
             asm.ORA(status_bit, asm.IMM8),
-            asm.STA(status_address, asm.ABS_X),
+            asm.STA(status_address, opcode),
+        ]
+        if(opcode == asm.ABS_Y):
+            src += [
+                asm.XY8(), # revert back to 8-bit X&Y
+                asm.PLY(), # pull original Y
+            ]
+        src += [
             asm.RTS(),
         ]
         space = Write(Bank.F0, src, auto_status_name)

--- a/constants/objectives/results.py
+++ b/constants/objectives/results.py
@@ -85,6 +85,9 @@ category_types = {
     ],
 }
 
+category_types["Auto"].append(ResultType(61, "Auto Dog Block", "Auto Dog Block", None))
+category_types["Auto"].append(ResultType(62, "Auto Life 3", "Auto Life 3", None))
+
 categories = list(category_types.keys())
 
 id_type = {}

--- a/objectives/results/auto_dog_block.py
+++ b/objectives/results/auto_dog_block.py
@@ -1,0 +1,14 @@
+from objectives.results._objective_result import *
+
+class Field(field_result.Result):
+    def src(self):
+        return []
+
+class Battle(battle_result.Result):
+    def src(self):
+        return []
+
+class Result(ObjectiveResult):
+    NAME = "Auto Dog Block"
+    def __init__(self):
+        super().__init__(Field, Battle)

--- a/objectives/results/auto_life_3.py
+++ b/objectives/results/auto_life_3.py
@@ -1,0 +1,14 @@
+from objectives.results._objective_result import *
+
+class Field(field_result.Result):
+    def src(self):
+        return []
+
+class Battle(battle_result.Result):
+    def src(self):
+        return []
+
+class Result(ObjectiveResult):
+    NAME = "Auto Life 3"
+    def __init__(self):
+        super().__init__(Field, Battle)


### PR DESCRIPTION
Tested with `py wc.py -i ../rom/ff3.sfc -oa 61.0.0 -ob 62.0.0 -sc1 terra -sc2 gau -sc3 umaro -sc4 mog`
(on beta, it's `-oa 63.0.0 and -ob 64.0.0` due to objective result conflicts with Perma KT Skip and Gauntlet)

Testing on beta: https://www.youtube.com/watch?v=36u-5pwHEKw&ab_channel=SilverThorn

Confirmed that each character has Life 3 and Dog Block in battle.

Confirmed that after battle, the 0x1615 + (0x25*i) gets reset back to 0x40 (so that only Dog Block is set).