### PR TITLE
Feature: Adding random-encounters-chupon flag

### DIFF
--- a/args/encounters.py
+++ b/args/encounters.py
@@ -10,6 +10,8 @@ def parse(parser):
     random.add_argument("-rer", "--random-encounters-random",
                         default = None, type = int, metavar = "PERCENT", choices = range(101),
                         help = "Random encounters are randomized")
+    random.add_argument("-rechu", "--random-encounters-chupon", action = "store_true",
+                        help = "All Random Encounters are replaced with Chupon (Coliseum)")
 
     fixed = encounters.add_mutually_exclusive_group()
     fixed.add_argument("-fer", "--fixed-encounters-random",
@@ -33,6 +35,8 @@ def flags(args):
         flags += " -res"
     elif args.random_encounters_random is not None:
         flags += f" -rer {args.random_encounters_random}"
+    elif args.random_encounters_chupon:
+        flags += " -rechu"
 
     if args.fixed_encounters_random is not None:
         flags += f" -fer {args.fixed_encounters_random}"
@@ -50,6 +54,8 @@ def options(args):
         random_encounters = "Shuffle"
     elif args.random_encounters_random is not None:
         random_encounters = "Random"
+    elif args.random_encounters_chupon:
+        random_encounters = "Chupon"
 
     result.append(("Random Encounters", random_encounters))
     if args.random_encounters_random is not None:

--- a/data/enemies.py
+++ b/data/enemies.py
@@ -269,6 +269,21 @@ class Enemies():
 
         # NOTE: any remaining formations (due to extra_formations) are lost
 
+    def chupon_encounters(self, maps):
+        # find all packs that are randomly encountered in zones
+        packs = []
+        for zone in self.zones.zones:
+            if self.skip_shuffling_zone(maps, zone):
+                continue
+
+            for x in range(zone.PACK_COUNT):
+                if self.skip_shuffling_pack(zone.packs[x], zone.encounter_rates[x]):
+                    continue
+
+                packs.append(zone.packs[x])
+
+        self.packs.chupon_packs(packs)
+        
     def randomize_encounters(self, maps):
         # find all packs that are randomly encountered in zones
         packs = []
@@ -326,6 +341,8 @@ class Enemies():
 
         if self.args.random_encounters_shuffle:
             self.shuffle_encounters(maps)
+        elif self.args.random_encounters_chupon:
+            self.chupon_encounters(maps)
         elif not self.args.random_encounters_original:
             self.randomize_encounters(maps)
 

--- a/data/enemy_formations.py
+++ b/data/enemy_formations.py
@@ -15,6 +15,7 @@ class EnemyFormations():
     DOOM_GAZE = 463
     PRESENTER = 433
     COLISEUM = 575
+    CHUPON = 563 # Otherwise unused formation -- we'll use it for the random_encounters_chupon flag.
 
     def __init__(self, rom, args, enemies):
         self.rom = rom
@@ -105,6 +106,18 @@ class EnemyFormations():
         self.formations[456].enemy_x_positions[0] = 1 # painting
         self.formations[456].enemy_x_positions[1] = 1 # demon
 
+    def add_chupon(self):
+        # Add Chupon (Coliseum) to an unused formation for use with random_encounters_chupon
+        self.formations[self.CHUPON].enemy_ids[0] = 64 # Chupon (Coliseum)
+        self.formations[self.CHUPON].enemy_slots = 1
+        self.formations[self.CHUPON].not_on_veldt = 1
+        self.formations[self.CHUPON].disable_back_attack = 1
+        self.formations[self.CHUPON].disable_pincer_attack = 1
+        self.formations[self.CHUPON].disable_side_attack = 1
+        self.formations[self.CHUPON].enemy_y_positions[0] = 5
+        self.formations[self.CHUPON].enemy_x_positions[0] = 6
+        self.formations[self.CHUPON].mold = 6 << 4
+
     def write(self):
         for formation_index in range(len(self.formations)):
             self.flags_data[formation_index] = self.formations[formation_index].flags_data()
@@ -130,6 +143,9 @@ class EnemyFormations():
             # move chadarnook to left edge of screen, somewhat misaligns on the original owzer's mansion battle background
             # but it looks better than having chadarnook's left edge showing on all the other battle backgrounds
             self.set_chadarnook_position_left_screen()
+
+        if self.args.random_encounters_chupon:
+            self.add_chupon()
 
     def print_scripts(self):
         for formation_index, formation in enumerate(self.formations):

--- a/data/enemy_packs.py
+++ b/data/enemy_packs.py
@@ -206,6 +206,12 @@ class EnemyPacks():
                 for formation_index in range(self.packs[pack_id].FORMATION_COUNT):
                     self.packs[pack_id].formations[formation_index] = self.formations.get_random_normal()
 
+    def chupon_packs(self, packs):
+        # Replace all packs with the CHUPON formation
+        for pack_id in packs:
+            for formation_index in range(self.packs[pack_id].FORMATION_COUNT):
+                self.packs[pack_id].formations[formation_index] = self.formations.CHUPON
+
     def randomize_fixed(self):
         lete_river = [263, 264] # nautiloid, exocite, pterodon
         imperial_camp = [272, 298, 300, 269, 270] # soldier, dogs, templar/soldier, final 3 battles

--- a/data/enemy_scripts.py
+++ b/data/enemy_scripts.py
@@ -257,6 +257,12 @@ class EnemyScripts():
         ]
         magic_urn_script.remove(life)
 
+    def chupon_sneeze_all(self):
+        # Make Chupon 64 (Coliseum) target all allies with initial sneeze
+        chupon_id = 64
+        chupon_script = self.scripts[chupon_id]
+        chupon_script.insert(0, ai_instr.SetTarget(0x43)) # Target: Allies
+
     def mod(self):
         # first free up some space for other mods
         self.cleanup_mod()
@@ -297,6 +303,9 @@ class EnemyScripts():
         if self.args.permadeath:
             self.hidon_no_chokesmoke()
             self.magic_urn_no_life()
+
+        if self.args.random_encounters_chupon:
+            self.chupon_sneeze_all()
 
         if self.args.ability_scaling:
             self.enemy_script_abilities.scale_abilities_mod()


### PR DESCRIPTION
Flag added to support kaizo and other seeds in which random encounters should be effectively disabled in all cases. 

Testing notes:

- Confirmed in ff3usme and ff6tools that the expected encounters are replaced with Chupon.
- Ran into a random encounter and confirmed it was Chupon Coliseum:
![image](https://user-images.githubusercontent.com/96998881/170167761-b22f6570-50dd-4078-8ba5-ee4e6338be90.png)
- Confirmed that Veldt is unaffected:
![image](https://user-images.githubusercontent.com/96998881/170168156-def6f2d8-fb7f-4366-9f30-b4b5fab332a4.png)
- Confirmed that fixed encounters are unaffected:
![image](https://user-images.githubusercontent.com/96998881/170168393-35a1e2a0-3075-451d-8090-444252effd36.png)
![image](https://user-images.githubusercontent.com/96998881/170168597-7a55b180-a6bd-41c1-9635-4786559b3769.png)
- Confirmed that zone eater is unaffected:
![image](https://user-images.githubusercontent.com/96998881/170393078-34f165b9-2db8-49d9-809d-843a79429ff6.png)


