### PR TITLE
Feature: add --start-junk flag

### DIFF
--- a/args/starting_gold_items.py
+++ b/args/starting_gold_items.py
@@ -14,7 +14,9 @@ def parse(parser):
     starting_gold_items.add_argument("-sfd", "--start-fenix-downs", default = 0, type = int, choices = range(11), metavar = "COUNT",
                                      help = "Start game with %(metavar)s Fenix Downs")
     starting_gold_items.add_argument("-sto", "--start-tools", default = 0, type = int, choices = range(9), metavar = "COUNT",
-                                     help = "Start game with %(metavar)s different random tools")
+                                     help = "Start game with %(metavar)s different random tools"),
+    starting_gold_items.add_argument("-sj", "--start-junk", default = 0, type = int, choices = range(25), metavar = "COUNT",
+                                     help = "Start game with %(metavar)s unique low tier items. Includes weapons, armors, helmets, and shields"),
 
 def process(args):
     pass
@@ -32,6 +34,8 @@ def flags(args):
         flags += f" -sfd {args.start_fenix_downs}"
     if args.start_tools != 0:
         flags += f" -sto {args.start_tools}"
+    if args.start_junk != 0:
+        flags += f" -sj {args.start_junk}"
 
     return flags
 
@@ -42,6 +46,7 @@ def options(args):
         ("Start Warp Stones", args.start_warp_stones),
         ("Start Fenix Downs", args.start_fenix_downs),
         ("Start Tools", args.start_tools),
+        ("Start Junk", args.start_junk),
     ]
 
 def menu(args):

--- a/args/starting_gold_items.py
+++ b/args/starting_gold_items.py
@@ -16,7 +16,7 @@ def parse(parser):
     starting_gold_items.add_argument("-sto", "--start-tools", default = 0, type = int, choices = range(9), metavar = "COUNT",
                                      help = "Start game with %(metavar)s different random tools"),
     starting_gold_items.add_argument("-sj", "--start-junk", default = 0, type = int, choices = range(25), metavar = "COUNT",
-                                     help = "Start game with %(metavar)s unique low tier items. Includes weapons, armors, helmets, and shields"),
+                                     help = "Start game with %(metavar)s unique low tier items. Includes weapons, armors, helmets, shields, and relics"),
 
 def process(args):
     pass

--- a/event/start.py
+++ b/event/start.py
@@ -196,6 +196,7 @@ class Start(Event):
         junk += tiers[Item.SHIELD][0]
         junk += tiers[Item.HELMET][0]
         junk += tiers[Item.ARMOR][0]
+        junk += tiers[Item.RELIC][0]
 
         start_junk = random.sample(junk, self.args.start_junk)
 

--- a/event/start.py
+++ b/event/start.py
@@ -188,6 +188,22 @@ class Start(Event):
                 field.AddItem(tool, sound_effect = False),
             ]
 
+        from constants.items import id_name
+        from data.shop_item_tiers import tiers
+        from data.item import Item
+        junk = []
+        junk += tiers[Item.WEAPON][0]
+        junk += tiers[Item.SHIELD][0]
+        junk += tiers[Item.HELMET][0]
+        junk += tiers[Item.ARMOR][0]
+
+        start_junk = random.sample(junk, self.args.start_junk)
+
+        for junk_id in start_junk:
+            src += [
+                field.AddItem(id_name[junk_id], sound_effect = False)
+            ]
+
         if self.args.debug:
             src += [
                 field.AddItem("Dried Meat", sound_effect = False),


### PR DESCRIPTION
Flag added to support kaizo. This would also work alongside "no starting gear" to make seed starts feel less "samey"

# Tests
`python3 ./wc.py -i ff3.smc -sj 12`  yields 12 low tier items to start with
![image](https://user-images.githubusercontent.com/95580337/170392817-7ddf85dc-139b-4bb9-9854-05d35f88a1dd.png)

`python3 ./wc.py -i ff3.smc -sj 24`  yields 24 low tier items to start with
![image](https://user-images.githubusercontent.com/95580337/170392748-ea790c99-087c-4039-b5ea-33a404ba92da.png)

