### PR TITLE
Feature: Add objective result Unlock Perma KT Skip

### DIFF
--- a/constants/objectives/results.py
+++ b/constants/objectives/results.py
@@ -15,7 +15,7 @@ category_types = {
     "Kefka's Tower" : [
         ResultType(1, "Kefka's Tower", "Random", None),
         ResultType(2, "Unlock Final Kefka", "Unlock Final Kefka", None),
-        ResultType(3, "Unlock KT Skip", "Unlock KT Skip", None),
+        ResultType(3, "Unlock One KT Skip", "Unlock One KT Skip", None),
     ],
     "Auto" : [
         ResultType(4, "Auto", "Random", None),
@@ -84,6 +84,8 @@ category_types = {
         ResultType(57, "Sour Mouth", "Sour Mouth", None),
     ],
 }
+
+category_types["Kefka's Tower"] += [ResultType(61, "Unlock Perma KT Skip", "Unlock Perma KT Skip", None)]
 
 categories = list(category_types.keys())
 

--- a/data/event_bit.py
+++ b/data/event_bit.py
@@ -202,8 +202,13 @@ TEMP_SONG_OVERRIDE = 0x1cc
 ENABLE_Y_PARTY_SWITCHING = 0x1ce
 ALWAYS_CLEAR = 0x176 # this event_bit is always clear, used for branching
 
-# bits 0x1e6-0x1ed  Unused, as the SNES versions feature 20 rare item slots rather than 30
-UNLOCKED_PERMA_KT_SKIP = 0x1e6 # custom
+# Unused Bits
+# bits 0x200-0x22e Used for banquet soldiers
+# 2 bits 0x1bc-0x1bd Unused
+# 3 bits 0x1c7-0x1c9 Unused
+# 3 bits 0x2c1-0x2c3 Unused
+UNLOCKED_PERMA_KT_SKIP = 0x2c1
+# 8 bits 0x1e6-0x1ed Unused, as the SNES versions feature 20 rare item slots rather than 30
 
 from constants.objectives import MAX_OBJECTIVES
 for index in range(MAX_OBJECTIVES):

--- a/data/event_bit.py
+++ b/data/event_bit.py
@@ -1,5 +1,5 @@
 # NOTE: (address - 1e80) * 0x8 + bit
-# e.g. (1eb7 - 1e80) * 0x8 + 0x1 = 1b9 (airship visible) 
+# e.g. (1eb7 - 1e80) * 0x8 + 0x1 = 1b9 (airship visible)
 #      (1f43 - 1e80) * 0x8 + 0x3 = 61b (characters on narshe battlefield)
 
 DISABLE_SAVE_POINT_TUTORIAL = 0x133
@@ -201,6 +201,9 @@ DISABLE_MENU_ACCESS = 0x1c2
 TEMP_SONG_OVERRIDE = 0x1cc
 ENABLE_Y_PARTY_SWITCHING = 0x1ce
 ALWAYS_CLEAR = 0x176 # this event_bit is always clear, used for branching
+
+# bits 0x1e6-0x1ed  Unused, as the SNES versions feature 20 rare item slots rather than 30
+UNLOCKED_PERMA_KT_SKIP = 0x1e6 # custom
 
 from constants.objectives import MAX_OBJECTIVES
 for index in range(MAX_OBJECTIVES):

--- a/event/kefka_tower.py
+++ b/event/kefka_tower.py
@@ -148,6 +148,7 @@ class KefkaTower(Event):
         space.add_label("ENTRANCE_LANDING", space.end_address + 1)
         space.write(
             field.BranchIfEventWordLess(event_word.CHARACTERS_AVAILABLE, 3, "NEED_MORE_ALLIES"),
+            field.BranchIfEventBitSet(event_bit.UNLOCKED_PERMA_KT_SKIP, "LANDING_MENU"),
             field.BranchIfEventBitSet(event_bit.UNLOCKED_KT_SKIP, "LANDING_MENU"),
 
             field.Pause(2), # NOTE: load-bearing pause, without a pause or dialog before party select the game

--- a/objectives/results/unlock_one_kt_skip.py
+++ b/objectives/results/unlock_one_kt_skip.py
@@ -1,0 +1,19 @@
+from objectives.results._objective_result import *
+import data.event_bit as event_bit
+
+class Field(field_result.Result):
+    def src(self):
+        return [
+            field.SetEventBit(event_bit.UNLOCKED_KT_SKIP),
+        ]
+
+class Battle(battle_result.Result):
+    def src(self):
+        return [
+            battle_result.SetBit(event_bit.address(event_bit.UNLOCKED_KT_SKIP), event_bit.UNLOCKED_KT_SKIP),
+        ]
+
+class Result(ObjectiveResult):
+    NAME = "Unlock One KT Skip"
+    def __init__(self):
+        super().__init__(Field, Battle)

--- a/objectives/results/unlock_perma_kt_skip.py
+++ b/objectives/results/unlock_perma_kt_skip.py
@@ -4,16 +4,16 @@ import data.event_bit as event_bit
 class Field(field_result.Result):
     def src(self):
         return [
-            field.SetEventBit(event_bit.UNLOCKED_KT_SKIP),
+            field.SetEventBit(event_bit.UNLOCKED_PERMA_KT_SKIP),
         ]
 
 class Battle(battle_result.Result):
     def src(self):
         return [
-            battle_result.SetBit(event_bit.address(event_bit.UNLOCKED_KT_SKIP), event_bit.UNLOCKED_KT_SKIP),
+            battle_result.SetBit(event_bit.address(event_bit.UNLOCKED_PERMA_KT_SKIP), event_bit.UNLOCKED_PERMA_KT_SKIP),
         ]
 
 class Result(ObjectiveResult):
-    NAME = "Unlock KT Skip"
+    NAME = "Unlock Perma KT Skip"
     def __init__(self):
         super().__init__(Field, Battle)


### PR DESCRIPTION
Added `Unlock Perma KT Skip` result, which will function similarly to the skip prior to 1.0 release where it will not be reset upon warping out

Renamed the previous skip result to "Unlock One KT Skip" so it is more clear that it is not repeatable

## Testing
**Unlock One KT Skip** 
Preview: https://youtu.be/yOqwj_9Gxbk
- `wc.py -i /ff3.smc -oa 2.0.0 -ob 3.0.0 -sc1 random -sc2 random -sc3 random -sws 5`
----------------
**Unlock Perma KT Skip**
Preview: https://youtu.be/GeqFQ9tIl98
- `wc.py -i /ff3.smc -oa 2.0.0 -ob 61.0.0 -sc1 random -sc2 random -sc3 random -sws 5`
-----------------
**Neither Skip**
No preview for this one, but tested locally and it works
- `wc.py -i /ff3.smc -oa 2.0.0 -sc1 random -sc2 random -sc3 random -sws 5`