### PR TITLE
Feature: Adding -llr flag to randomize L.x lore levels

### DIFF
--- a/args/lores.py
+++ b/args/lores.py
@@ -23,6 +23,9 @@ def parse(parser):
     lores.add_argument("-lel", "--lores-everyone-learns", action = "store_true",
                        help = "Lores learnable by characters without the Lore command")
 
+    lores.add_argument("-llr", "--lores-level-randomize", action = "store_true",
+                       help = "Level based lores will have the level randomized (L?, L1-L5)")
+
 def process(args):
     args._process_min_max("start_lores_random")
     args._process_min_max("lores_mp_random_value")
@@ -44,6 +47,8 @@ def flags(args):
     if args.lores_everyone_learns:
         flags += " -lel"
 
+    if args.lores_level_randomize:
+        flags += " -llr"
     return flags
 
 def options(args):
@@ -63,6 +68,7 @@ def options(args):
         ("Start Lores", start_lores),
         ("MP", mp),
         ("Everyone Learns", args.lores_everyone_learns),
+        ("Lx Level Random", args.lores_level_randomize)
     ]
 
 def menu(args):

--- a/data/data.py
+++ b/data/data.py
@@ -46,7 +46,7 @@ class Data:
         self.blitzes.mod()
 
         self.lores = lores.Lores(rom, args, self.characters)
-        self.lores.mod()
+        self.lores.mod(self.dialogs)
 
         self.rages = rages.Rages(rom, args, self.enemies)
         self.rages.mod()

--- a/data/lore.py
+++ b/data/lore.py
@@ -2,11 +2,12 @@ from data.ability_data import AbilityData
 import data.text as text
 
 class Lore(AbilityData):
-    def __init__(self, id, name_data, ability_data):
+    def __init__(self, id, name_data, ability_data, desc_data):
         super().__init__(id, ability_data)
 
         self.id = id
         self.name = text.get_string(name_data, text.TEXT2).rstrip('\0')
+        self.desc = text.get_string(desc_data, text.TEXT2).rstrip('\0')
 
     def name_data(self):
         from data.lores import Lores
@@ -14,8 +15,16 @@ class Lore(AbilityData):
         data.extend([0xff] * (Lores.NAME_SIZE - len(data)))
         return data
 
+    def desc_data(self):
+        from data.lores import Lores
+        data = text.get_bytes(self.desc, text.TEXT2)
+        return data
+
     def get_name(self):
         return self.name.strip('\0')
+
+    def get_desc(self):
+        return self.desc.strip('\0')
 
     def print(self):
         print(f"{self.id} {self.get_name()}")

--- a/data/lores.py
+++ b/data/lores.py
@@ -9,6 +9,8 @@ class Lores:
     LORE_COUNT = 24
     CONDEMNED, ROULETTE, CLEAN_SWEEP, AQUA_RAKE, AERO, BLOW_FISH, BIG_GUARD, REVENGE, PEARL_WIND, L_5_DOOM, L_4_FLARE, L_3_MUDDLE, REFLECT, L_PEARL, STEP_MINE, FORCE_FIELD, DISCHORD, SOUR_MOUTH, PEP_UP, RIPPLER, STONE, QUASAR, GRAND_TRAIN, EXPLODER = range(LORE_COUNT)
 
+    DIALOG_OFFSET = 139 # starting offset for battle dialog
+
     INITIAL_LORES_START = 0x26f564
     INITIAL_LORES_END = 0x26f566
 
@@ -185,7 +187,7 @@ class Lores:
             raise ValueError(f'Unexpected lore index: {lore_index}')
         return new_desc
 
-    def random_lx_levels(self):
+    def random_lx_levels(self, dialogs):
         import random, re
         LX_LORE_IDX = [Lores.L_5_DOOM, Lores.L_4_FLARE, Lores.L_3_MUDDLE, Lores.L_PEARL]
         LQ_EFFECT = 29 # the AbilityData.effect setting for L?
@@ -208,8 +210,10 @@ class Lores:
                 lore.effect = LQ_EFFECT
             lore.name = re.sub('L.*[?1-9]', f'L.{level_divisor}', lore.name)
             lore.desc = Lores._get_new_level_desc(lore_index, level_divisor)
+            battle_message = re.sub('<dotted line>', '“', lore.desc)
+            dialogs.set_battle_message_text(self.DIALOG_OFFSET + lore_index, battle_message)
 
-    def mod(self):
+    def mod(self, dialogs):
         self.write_learners_table()
         self.write_is_learner()
         self.after_battle_check_mod()
@@ -225,7 +229,7 @@ class Lores:
             self.random_mp_percent()
 
         if self.args.lores_level_randomize:
-            self.random_lx_levels()
+            self.random_lx_levels(dialogs)
 
     def write(self):
         if self.args.spoiler_log:

--- a/data/lores.py
+++ b/data/lores.py
@@ -1,8 +1,8 @@
 from data.lore import Lore
 from data.ability_data import AbilityData
-from data.structures import DataBits, DataArray
+from data.structures import DataBits, DataArray, DataList
 
-from memory.space import Bank, Reserve, Allocate, Write
+from memory.space import Bank, Reserve, Allocate, Write, Space
 import instruction.asm as asm
 
 class Lores:
@@ -16,6 +16,12 @@ class Lores:
     NAMES_END = 0x26fb65
     NAME_SIZE = 10
 
+    DESC_PTRS_START = 0x2d7a70
+    DESC_PTRS_END = 0x2d7a9f
+
+    DESC_START = 0x2d77a0
+    DESC_END = 0x2d7a6f
+
     ABILITY_DATA_START = 0x04725a
     ABILITY_DATA_END = 0x0473a9
 
@@ -28,9 +34,13 @@ class Lores:
         self.name_data = DataArray(self.rom, self.NAMES_START, self.NAMES_END, self.NAME_SIZE)
         self.ability_data = DataArray(self.rom, self.ABILITY_DATA_START, self.ABILITY_DATA_END, AbilityData.DATA_SIZE)
 
+        self.desc_data = DataList(Space.rom, self.DESC_PTRS_START, self.DESC_PTRS_END,
+                                    Space.rom.SHORT_PTR_SIZE, self.DESC_START,
+                                    self.DESC_START, self.DESC_END)
+
         self.lores = []
         for lore_index in range(len(self.ability_data)):
-            lore = Lore(lore_index, self.name_data[lore_index], self.ability_data[lore_index])
+            lore = Lore(lore_index, self.name_data[lore_index], self.ability_data[lore_index], self.desc_data[lore_index])
             self.lores.append(lore)
 
     def write_learners_table(self):
@@ -160,6 +170,45 @@ class Lores:
             value = int(lore.mp * mp_percent)
             lore.mp = max(min(value, 255), 0)
 
+    def _get_new_level_desc(lore_index, level_divisor):
+        level_string = f'LV{level_divisor}' # keeping it simple to not use extra space
+        new_desc = ''
+        if(lore_index == Lores.L_5_DOOM):
+            new_desc = f'Casts <dotted line>Doom" on {level_string} enemy<end>'
+        elif(lore_index == Lores.L_4_FLARE):
+            new_desc = f'Casts <dotted line>Flare" on {level_string} enemy<end>'
+        elif(lore_index == Lores.L_3_MUDDLE):
+            new_desc = f'Casts <dotted line>Muddle" on {level_string} enemy<end>'
+        elif(lore_index == Lores.L_PEARL):
+            new_desc = f'Pearl attack on {level_string} enemy<end>'
+        else:
+            raise ValueError(f'Unexpected lore index: {lore_index}')
+        return new_desc
+
+    def random_lx_levels(self):
+        import random, re
+        LX_LORE_IDX = [Lores.L_5_DOOM, Lores.L_4_FLARE, Lores.L_3_MUDDLE, Lores.L_PEARL]
+        LQ_EFFECT = 29 # the AbilityData.effect setting for L?
+        NO_EFFECT = 255 # The AbilityData.effect setting for no effect
+        MAX_DIVISOR = 5
+
+        for lore_index in LX_LORE_IDX:
+            lore = self.lores[lore_index]
+
+            level_divisor = random.randint(0, MAX_DIVISOR)
+            if lore_index == Lores.L_5_DOOM:
+                # prevent soft-locks with bosses by removing unmissable doom
+                level_divisor = random.randint(2, MAX_DIVISOR) 
+
+            lore.accuracy = level_divisor
+            if level_divisor: # non-zero
+                lore.effect = NO_EFFECT
+            else: # zero - use for L?
+                level_divisor = '?'
+                lore.effect = LQ_EFFECT
+            lore.name = re.sub('L.*[?1-9]', f'L.{level_divisor}', lore.name)
+            lore.desc = Lores._get_new_level_desc(lore_index, level_divisor)
+
     def mod(self):
         self.write_learners_table()
         self.write_is_learner()
@@ -175,6 +224,9 @@ class Lores:
         elif self.args.lores_mp_random_percent:
             self.random_mp_percent()
 
+        if self.args.lores_level_randomize:
+            self.random_lx_levels()
+
     def write(self):
         if self.args.spoiler_log:
             self.log()
@@ -182,10 +234,12 @@ class Lores:
         for lore_index, lore in enumerate(self.lores):
             self.name_data[lore_index] = lore.name_data()
             self.ability_data[lore_index] = lore.ability_data()
+            self.desc_data[lore_index] = lore.desc_data()
 
         self.init_data.write()
         self.name_data.write()
         self.ability_data.write()
+        self.desc_data.write()
 
     def log(self):
         from log import section


### PR DESCRIPTION
Added `-llr` flag to randomize L.x lore levels (L.5 Doom, L? Pearl, L.3 Muddle, L.4 Flare). All except L.5 Doom can be L?, L1-L5. L.5 Doom can be L2-L5 to avoid soft-lock possibility with Doom Gaze or other random-ability bosses.

Tested by rolling a bunch of seeds with these flags and fighting Leafers/Dark Winds of growing levels:
`-llr -sc1 strago -slr 24 24 -lmprp 0 0 -lst 0.5`

Also confirmed via ff3usme that the expected changes were made to the Lore data:

![image](https://user-images.githubusercontent.com/96998881/184443566-218b65b2-bed9-41ce-977d-970d87574718.png)
![image](https://user-images.githubusercontent.com/96998881/184443585-1f2b7e50-165f-47bd-bd05-7d859730445c.png)
![image](https://user-images.githubusercontent.com/96998881/184443985-008421dd-cd50-4920-8c54-4d98756f6c6a.png)

Finally, confirmed that battle dialogs are updated:
![image](https://user-images.githubusercontent.com/96998881/200204767-8fb96721-b94a-440d-aedb-29c4ee2e1e7c.png)


